### PR TITLE
main: fix segfault because of lv_task_handler() concurrently called

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -630,6 +630,11 @@ public:
           lv_label_set_text_static(screen_off_label, "Screen is OFF");
           lv_obj_align(screen_off_label, nullptr, LV_ALIGN_CENTER, 0, -20);
         }
+        /* Periodically call the lv_task handler.
+        * It could be done in a timer interrupt or an OS task too.*/
+        // only call the task handler if the screen is off,
+        // when the screen is enabled the call is done in the SystemTask class
+        lv_task_handler();
       } else {
         if (screen_off_created) {
           screen_off_created = false;
@@ -722,9 +727,6 @@ int main(int argc, char **argv)
   Framework fw(fw_status_window_visible, 240,240);
 
   while(1) {
-      /* Periodically call the lv_task handler.
-       * It could be done in a timer interrupt or an OS task too.*/
-      lv_task_handler();
       fw.handle_keys(); // key event polling
       fw.handle_touch_and_button();
       fw.refresh();


### PR DESCRIPTION
Both InfiniSim/main.cpp and SystemTask.cpp periodically called
`lv_task_handler()`. This introduces a race condition, which leads to a
segmentation fault in either the main or the SystemTasks call of
`lv_task_handler()`.

Now `main` only calls the `lv_task_handler()` if the `SystemTask` does
not (while the screen is turned off). We need this for the Simulator,
otherwise the "Screen is OFF" message won't appear, and the right mouse
button won't be recognized to wake up the simulated screen.

Fixes: https://github.com/InfiniTimeOrg/InfiniSim/issues/3