### PR TITLE
Fix libpng submodule usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -236,6 +236,8 @@ option(WITH_PNG "Compile with libpng support to dump current screen as png" ON)
 if(WITH_PNG)
   target_compile_definitions(infinisim PRIVATE WITH_PNG)
   add_subdirectory(libpng EXCLUDE_FROM_ALL)
+  target_include_directories(infinisim PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+  target_include_directories(infinisim PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/libpng")
   target_link_libraries(infinisim PRIVATE png_static)
 endif()
 

--- a/main.cpp
+++ b/main.cpp
@@ -61,7 +61,7 @@
 #include <date/date.h>
 #include <chrono>
 #if defined(WITH_PNG)
-#include <libpng16/png.h>
+#include <libpng/png.h>
 #endif
 
 /*********************


### PR DESCRIPTION
The current usage used the system `png.h` header instead of the intended
submodule header. This may break if the system header isn't at
`libpng16/png.h`.

Fix the include header to get the genreated include files and the
`png.h` from the submodule as described in
https://github.com/glennrp/libpng/issues/342#issuecomment-864589614

Fixes: https://github.com/InfiniTimeOrg/InfiniSim/issues/19