### PR TITLE
CI: install lv_font_conv binary

### DIFF
--- a/.github/workflows/lv_sim.yml
+++ b/.github/workflows/lv_sim.yml
@@ -34,6 +34,10 @@ jobs:
           sudo apt-get update
           sudo apt-get -y install libsdl2-dev
 
+      - name: Install lv_font_conv
+        run:
+          npm i -g lv_font_conv@1.5.2
+
       #########################################################################################
       # Checkout
 


### PR DESCRIPTION
We consider in CMake if we add the font subdir, but we didn't install
the `lv_font_conv` binary in https://github.com/InfiniTimeOrg/InfiniSim/pull/29