### PR TITLE
Fix notification segfault

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -515,7 +515,7 @@ public:
       notificationManager.Push(std::move(notif));
       // send next message the next time
       notification_idx++;
-      if (notification_idx >= notification_messages.size()) {
+      if (notification_idx >= notification_messages.size()/2) {
         notification_idx = 0;
       }
     }


### PR DESCRIPTION
Need to loop the notification_idx after half the notification_messages
size since the change of splitting the subject and message body into two
strings.