### PR TITLE
LittleVgl: implement screen transitions like on PineTime

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -863,21 +863,21 @@ static void hal_init(void)
   SDL_CreateThread(tick_thread, "tick", NULL);
 
   // use pinetime_theme
-  lv_theme_t* th = lv_pinetime_theme_init(
-    LV_COLOR_WHITE, LV_COLOR_SILVER, 0, &jetbrains_mono_bold_20, &jetbrains_mono_bold_20, &jetbrains_mono_bold_20, &jetbrains_mono_bold_20);
-  lv_theme_set_act(th);
+  //lv_theme_t* th = lv_pinetime_theme_init(
+  //  LV_COLOR_WHITE, LV_COLOR_SILVER, 0, &jetbrains_mono_bold_20, &jetbrains_mono_bold_20, &jetbrains_mono_bold_20, &jetbrains_mono_bold_20);
+  //lv_theme_set_act(th);
 
-  /*Create a display buffer*/
-  static lv_disp_buf_t disp_buf1;
-  static lv_color_t buf1_1[LV_HOR_RES_MAX * 120];
-  lv_disp_buf_init(&disp_buf1, buf1_1, NULL, LV_HOR_RES_MAX * 120);
+  ///*Create a display buffer*/
+  //static lv_disp_buf_t disp_buf1;
+  //static lv_color_t buf1_1[LV_HOR_RES_MAX * 120];
+  //lv_disp_buf_init(&disp_buf1, buf1_1, NULL, LV_HOR_RES_MAX * 120);
 
-  /*Create a display*/
-  lv_disp_drv_t disp_drv;
-  lv_disp_drv_init(&disp_drv); /*Basic initialization*/
-  disp_drv.buffer = &disp_buf1;
-  disp_drv.flush_cb = monitor_flush;
-  lv_disp_drv_register(&disp_drv);
+  ///*Create a display*/
+  //lv_disp_drv_t disp_drv;
+  //lv_disp_drv_init(&disp_drv); /*Basic initialization*/
+  //disp_drv.buffer = &disp_buf1;
+  //disp_drv.flush_cb = monitor_flush;
+  //lv_disp_drv_register(&disp_drv);
 
   /* Add the mouse as input device
    * Use the 'mouse' driver which reads the PC's mouse*/

--- a/sim/displayapp/LittleVgl.cpp
+++ b/sim/displayapp/LittleVgl.cpp
@@ -3,9 +3,15 @@
 
 #include <FreeRTOS.h>
 #include <task.h>
+#include <timers.h>
 ////#include <projdefs.h>
 #include "drivers/Cst816s.h"
 #include "drivers/St7789.h"
+
+// lv-sim monitor display driver for monitor_flush() function
+#include "lv_drivers/display/monitor.h"
+
+#include <array>
 
 using namespace Pinetime::Components;
 
@@ -37,8 +43,8 @@ LittleVgl::LittleVgl(Pinetime::Drivers::St7789& lcd, Pinetime::Drivers::Cst816S&
 
 void LittleVgl::Init() {
 //  lv_init();
-//  InitTheme();
-//  InitDisplay();
+  InitTheme();
+  InitDisplay();
   InitTouchpad();
 }
 
@@ -91,105 +97,171 @@ void LittleVgl::SetFullRefresh(FullRefreshDirections direction) {
   fullRefresh = true;
 }
 
-void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
-//  uint16_t y1, y2, width, height = 0;
-//
-//  ulTaskNotifyTake(pdTRUE, 200);
-//  // Notification is still needed (even if there is a mutex on SPI) because of the DataCommand pin
-//  // which cannot be set/clear during a transfer.
-//
-//  if ((scrollDirection == LittleVgl::FullRefreshDirections::Down) && (area->y2 == visibleNbLines - 1)) {
-//    writeOffset = ((writeOffset + totalNbLines) - visibleNbLines) % totalNbLines;
-//  } else if ((scrollDirection == FullRefreshDirections::Up) && (area->y1 == 0)) {
-//    writeOffset = (writeOffset + visibleNbLines) % totalNbLines;
-//  }
-//
-//  y1 = (area->y1 + writeOffset) % totalNbLines;
-//  y2 = (area->y2 + writeOffset) % totalNbLines;
-//
-//  width = (area->x2 - area->x1) + 1;
-//  height = (area->y2 - area->y1) + 1;
-//
-//  if (scrollDirection == LittleVgl::FullRefreshDirections::Down) {
-//
-//    if (area->y2 < visibleNbLines - 1) {
-//      uint16_t toScroll = 0;
-//      if (area->y1 == 0) {
-//        toScroll = height * 2;
-//        scrollDirection = FullRefreshDirections::None;
-//        lv_disp_set_direction(lv_disp_get_default(), 0);
-//      } else {
-//        toScroll = height;
-//      }
-//
-//      if (scrollOffset >= toScroll)
-//        scrollOffset -= toScroll;
-//      else {
-//        toScroll -= scrollOffset;
-//        scrollOffset = (totalNbLines) -toScroll;
-//      }
-//      lcd.VerticalScrollStartAddress(scrollOffset);
-//    }
-//
-//  } else if (scrollDirection == FullRefreshDirections::Up) {
-//
-//    if (area->y1 > 0) {
-//      if (area->y2 == visibleNbLines - 1) {
-//        scrollOffset += (height * 2);
-//        scrollDirection = FullRefreshDirections::None;
-//        lv_disp_set_direction(lv_disp_get_default(), 0);
-//      } else {
-//        scrollOffset += height;
-//      }
-//      scrollOffset = scrollOffset % totalNbLines;
-//      lcd.VerticalScrollStartAddress(scrollOffset);
-//    }
-//  } else if (scrollDirection == FullRefreshDirections::Left or scrollDirection == FullRefreshDirections::LeftAnim) {
-//    if (area->x2 == visibleNbLines - 1) {
-//      scrollDirection = FullRefreshDirections::None;
-//      lv_disp_set_direction(lv_disp_get_default(), 0);
-//    }
-//  } else if (scrollDirection == FullRefreshDirections::Right or scrollDirection == FullRefreshDirections::RightAnim) {
-//    if (area->x1 == 0) {
-//      scrollDirection = FullRefreshDirections::None;
-//      lv_disp_set_direction(lv_disp_get_default(), 0);
-//    }
-//  }
-//
-//  if (y2 < y1) {
-//    height = totalNbLines - y1;
-//
-//    if (height > 0) {
-//      lcd.DrawBuffer(area->x1, y1, width, height, reinterpret_cast<const uint8_t*>(color_p), width * height * 2);
-//      ulTaskNotifyTake(pdTRUE, 100);
-//    }
-//
-//    uint16_t pixOffset = width * height;
-//    height = y2 + 1;
-//    lcd.DrawBuffer(area->x1, 0, width, height, reinterpret_cast<const uint8_t*>(color_p + pixOffset), width * height * 2);
-//
-//  } else {
-//    lcd.DrawBuffer(area->x1, y1, width, height, reinterpret_cast<const uint8_t*>(color_p), width * height * 2);
-//  }
-//
-//  // IMPORTANT!!!
-//  // Inform the graphics library that you are ready with the flushing
-//  lv_disp_flush_ready(&disp_drv);
+// glue the lvgl code to the lv-sim monitor driver
+void DrawBuffer(lv_disp_drv_t *disp_drv, uint16_t x, uint16_t y, uint16_t width, uint16_t height, uint8_t* data, size_t size) {
+  lv_area_t area;
+  area.x1 = x;
+  area.x2 = x+width-1;
+  area.y1 = y;
+  area.y2 = y+height-1;
+  lv_color_t* color_p = reinterpret_cast<lv_color_t*>(data);
+  monitor_flush(disp_drv, &area, color_p);
+}
 
+// copied from lv_drivers/display/monitor.c to get the SDL_Window for the InfiniTime screen
+extern "C"
+{
+typedef struct {
+  SDL_Window * window;
+  SDL_Renderer * renderer;
+  SDL_Texture * texture;
+  volatile bool sdl_refr_qry;
+#if MONITOR_DOUBLE_BUFFERED
+  uint32_t * tft_fb_act;
+#else
+  uint32_t tft_fb[LV_HOR_RES_MAX * LV_VER_RES_MAX];
+#endif
+}monitor_t;
+extern monitor_t monitor;
+}
+
+// positive height moves screen down (draw y=0 to y=height)
+// negative height moves screen up   (draw y=height to y=0)
+void MoveScreen(lv_disp_drv_t *disp_drv, int16_t height) {
+  if (height == 0)
+    return; // nothing to do
+
+  const int sdl_width = 240;
+  const int sdl_height = 240;
+  auto renderer = monitor.renderer;
+
+  const Uint32 format = SDL_PIXELFORMAT_RGBA8888;
+  SDL_Surface *surface = SDL_CreateRGBSurfaceWithFormat(0, sdl_width, sdl_height, 32, format);
+  SDL_RenderReadPixels(renderer, NULL, format, surface->pixels, surface->pitch);
+  uint8_t *pixels = (uint8_t*) surface->pixels;
+
+  std::array<lv_color16_t, 240*240> color_p;
+  for (int hi = 0; hi < sdl_height; hi++) {
+    for (int wi = 0; wi < sdl_width; wi++) {
+      auto red   = pixels[hi*surface->pitch + wi*4 + 3]; // red
+      auto green = pixels[hi*surface->pitch + wi*4 + 2]; // greeen
+      auto blue  = pixels[hi*surface->pitch + wi*4 + 1]; // blue
+      color_p.at(hi * sdl_width + wi) = LV_COLOR_MAKE(red, green, blue);
+    }
+  }
+  int16_t buffer_height = sdl_height - abs(height);
+  if (height >= 0) {
+    DrawBuffer(disp_drv, 0, height, sdl_width, sdl_height, (uint8_t*)color_p.data(), sdl_width*buffer_height *2);
+  } else {
+    DrawBuffer(disp_drv, 0, 0, sdl_width, sdl_height, (uint8_t*)(&color_p.at(sdl_width*abs(height))), sdl_width*buffer_height *2);
+  }
+}
+
+void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
+  uint16_t y1, y2, width, height = 0;
+
+  //ulTaskNotifyTake(pdTRUE, 200);
+  // Notification is still needed (even if there is a mutex on SPI) because of the DataCommand pin
+  // which cannot be set/clear during a transfer.
+
+  //if ((scrollDirection == LittleVgl::FullRefreshDirections::Down) && (area->y2 == visibleNbLines - 1)) {
+  //  writeOffset = ((writeOffset + totalNbLines) - visibleNbLines) % totalNbLines;
+  //} else if ((scrollDirection == FullRefreshDirections::Up) && (area->y1 == 0)) {
+  //  writeOffset = (writeOffset + visibleNbLines) % totalNbLines;
+  //}
+
+  y1 = (area->y1 + writeOffset) % totalNbLines;
+  y2 = (area->y2 + writeOffset) % totalNbLines;
+
+  width = (area->x2 - area->x1) + 1;
+  height = (area->y2 - area->y1) + 1;
+
+  if (scrollDirection == LittleVgl::FullRefreshDirections::Down) {
+
+    if (area->y2 < visibleNbLines - 1) {
+      uint16_t toScroll = 0;
+      if (area->y1 == 0) {
+        toScroll = height * 2;
+        scrollDirection = FullRefreshDirections::None;
+        lv_disp_set_direction(lv_disp_get_default(), 0);
+      } else {
+        toScroll = height;
+      }
+
+      if (scrollOffset >= toScroll)
+        scrollOffset -= toScroll;
+      else {
+        toScroll -= scrollOffset;
+        scrollOffset = (totalNbLines) -toScroll;
+      }
+      lcd.VerticalScrollStartAddress(scrollOffset);
+
+    }
+    // move the whole screen down and draw the new screen at the top of the display
+    MoveScreen(&disp_drv, static_cast<int16_t>(height));
+    y1 = 0;
+    y2 = height;
+
+  } else if (scrollDirection == FullRefreshDirections::Up) {
+
+    if (area->y1 > 0) {
+      if (area->y2 == visibleNbLines - 1) {
+        scrollOffset += (height * 2);
+        scrollDirection = FullRefreshDirections::None;
+        lv_disp_set_direction(lv_disp_get_default(), 0);
+      } else {
+        scrollOffset += height;
+      }
+      scrollOffset = scrollOffset % totalNbLines;
+      lcd.VerticalScrollStartAddress(scrollOffset);
+    }
+    // move the whole screen up and draw the new screen at the bottom the display
+    MoveScreen(&disp_drv, -static_cast<int16_t>(height));
+    y1 = LV_VER_RES - height;
+    y2 = LV_VER_RES;
+  } else if (scrollDirection == FullRefreshDirections::Left or scrollDirection == FullRefreshDirections::LeftAnim) {
+    if (area->x2 == visibleNbLines - 1) {
+      scrollDirection = FullRefreshDirections::None;
+      lv_disp_set_direction(lv_disp_get_default(), 0);
+    }
+  } else if (scrollDirection == FullRefreshDirections::Right or scrollDirection == FullRefreshDirections::RightAnim) {
+    if (area->x1 == 0) {
+      scrollDirection = FullRefreshDirections::None;
+      lv_disp_set_direction(lv_disp_get_default(), 0);
+    }
+  }
+
+  if (y2 < y1) {
+    height = totalNbLines - y1;
+
+    if (height > 0) {
+      //lcd.DrawBuffer(area->x1, y1, width, height, reinterpret_cast<const uint8_t*>(color_p), width * height * 2);
+      DrawBuffer(&disp_drv, area->x1, y1, width, height, reinterpret_cast<uint8_t*>(color_p), width * height * 2);
+      //ulTaskNotifyTake(pdTRUE, 100);
+    }
+
+    uint16_t pixOffset = width * height;
+    height = y2 + 1;
+    //lcd.DrawBuffer(area->x1, 0, width, height, reinterpret_cast<const uint8_t*>(color_p + pixOffset), width * height * 2);
+    DrawBuffer(&disp_drv, area->x1, 0, width, height, reinterpret_cast<uint8_t*>(color_p + pixOffset), width * height * 2);
+
+  } else {
+    //lcd.DrawBuffer(area->x1, y1, width, height, reinterpret_cast<const uint8_t*>(color_p), width * height * 2);
+    DrawBuffer(&disp_drv, area->x1, y1, width, height, reinterpret_cast<uint8_t*>(color_p), width * height * 2);
+  }
+
+  // IMPORTANT!!!
+  // Inform the graphics library that you are ready with the flushing
+  //lv_disp_flush_ready(&disp_drv);
+
+  // call flush with flushing_last set
+  // workaround because lv_disp_flush_ready() doesn't seem to trigger monitor_flush
   lv_disp_t *disp = lv_disp_get_default();
-  lv_disp_drv_t *disp_drv = &disp->driver;
-  lv_area_t area_trimmed = *area;
-  if (area->x1 < 0)
-    area_trimmed.x1 = 0;
-  if (area->x2 >= LV_HOR_RES)
-    area_trimmed.x2 = LV_HOR_RES-1;
-  if (area->y1 < 0)
-    area_trimmed.y1 = 0;
-  if (area->y2 >= LV_VER_RES)
-    area_trimmed.y2 = LV_VER_RES-1;
-  // tell flush_cb this is the last thing to flush to get the monitor refreshed
   lv_disp_get_buf(disp)->flushing_last = true;
-  disp_drv->flush_cb(disp_drv, &area_trimmed, color_p);
+  lv_area_t area_zero {0,0,0,0};
+  monitor_flush(&disp_drv, &area_zero, color_p);
+  // delay drawing to mimic PineTime display rendering speed
+  vTaskDelay(pdMS_TO_TICKS(3));
 }
 
 void LittleVgl::SetNewTouchPoint(uint16_t x, uint16_t y, bool contact) {

--- a/sim/displayapp/LittleVgl.cpp
+++ b/sim/displayapp/LittleVgl.cpp
@@ -1,57 +1,67 @@
 #include "displayapp/LittleVgl.h"
 #include "displayapp/lv_pinetime_theme.h"
 
-//#include <FreeRTOS.h>
-//#include <task.h>
+#include <FreeRTOS.h>
+#include <task.h>
 ////#include <projdefs.h>
 #include "drivers/Cst816s.h"
 #include "drivers/St7789.h"
 
 using namespace Pinetime::Components;
 
-//lv_style_t* LabelBigStyle = nullptr;
-//
-//static void disp_flush(lv_disp_drv_t* disp_drv, const lv_area_t* area, lv_color_t* color_p) {
-//  auto* lvgl = static_cast<LittleVgl*>(disp_drv->user_data);
-//  lvgl->FlushDisplay(area, color_p);
-//}
-//
+lv_style_t* LabelBigStyle = nullptr;
+
+static void disp_flush(lv_disp_drv_t* disp_drv, const lv_area_t* area, lv_color_t* color_p) {
+  auto* lvgl = static_cast<LittleVgl*>(disp_drv->user_data);
+  lvgl->FlushDisplay(area, color_p);
+}
+
+static void rounder(lv_disp_drv_t* disp_drv, lv_area_t* area) {
+  auto* lvgl = static_cast<LittleVgl*>(disp_drv->user_data);
+  if (lvgl->GetFullRefresh()) {
+    area->x1 = 0;
+    area->x2 = LV_HOR_RES - 1;
+    area->y1 = 0;
+    area->y2 = LV_VER_RES - 1;
+  }
+}
+
 bool touchpad_read(lv_indev_drv_t* indev_drv, lv_indev_data_t* data) {
   auto* lvgl = static_cast<LittleVgl*>(indev_drv->user_data);
   return lvgl->GetTouchPadInfo(data);
 }
 
 LittleVgl::LittleVgl(Pinetime::Drivers::St7789& lcd, Pinetime::Drivers::Cst816S& touchPanel)
-  : lcd {lcd}, touchPanel {touchPanel}, previousClick {0, 0} {
-
+  : lcd {lcd}, touchPanel {touchPanel} {
 }
 
 void LittleVgl::Init() {
 //  lv_init();
-//  InitDisplay();
 //  InitTheme();
+//  InitDisplay();
   InitTouchpad();
 }
 
-//void LittleVgl::InitDisplay() {
-//  lv_disp_draw_buf_init(&disp_buf_2, buf2_1, buf2_2, LV_HOR_RES_MAX * 4); /*Initialize the display buffer*/
-//  lv_disp_drv_init(&disp_drv);                                       /*Basic initialization*/
-//
-//  /*Set up the functions to access to your display*/
-//
-//  /*Set the resolution of the display*/
-//  disp_drv.hor_res = 240;
-//  disp_drv.ver_res = 240;
-//
-//  /*Used to copy the buffer's content to the display*/
-//  disp_drv.flush_cb = disp_flush;
-//  /*Set a display buffer*/
-//  disp_drv.draw_buf = &disp_buf_2;
-//  disp_drv.user_data = this;
-//
-//  /*Finally register the driver*/
-//  lv_disp_drv_register(&disp_drv);
-//}
+void LittleVgl::InitDisplay() {
+  lv_disp_buf_init(&disp_buf_2, buf2_1, buf2_2, LV_HOR_RES_MAX * 4); /*Initialize the display buffer*/
+  lv_disp_drv_init(&disp_drv);                                       /*Basic initialization*/
+
+  /*Set up the functions to access to your display*/
+
+  /*Set the resolution of the display*/
+  disp_drv.hor_res = 240;
+  disp_drv.ver_res = 240;
+
+  /*Used to copy the buffer's content to the display*/
+  disp_drv.flush_cb = disp_flush;
+  /*Set a display buffer*/
+  disp_drv.buffer = &disp_buf_2;
+  disp_drv.user_data = this;
+  disp_drv.rounder_cb = rounder;
+
+  /*Finally register the driver*/
+  lv_disp_drv_register(&disp_drv);
+}
 
 void LittleVgl::InitTouchpad() {
   lv_indev_drv_t indev_drv;
@@ -67,171 +77,30 @@ void LittleVgl::SetFullRefresh(FullRefreshDirections direction) {
   if (scrollDirection == FullRefreshDirections::None) {
     scrollDirection = direction;
     if (scrollDirection == FullRefreshDirections::Down) {
-      lv_disp_set_rotation(lv_disp_get_default(), LV_DISP_ROT_NONE);
+      lv_disp_set_direction(lv_disp_get_default(), 1);
     } else if (scrollDirection == FullRefreshDirections::Right) {
-      lv_disp_set_rotation(lv_disp_get_default(), LV_DISP_ROT_NONE);
+      lv_disp_set_direction(lv_disp_get_default(), 2);
     } else if (scrollDirection == FullRefreshDirections::Left) {
-      lv_disp_set_rotation(lv_disp_get_default(), LV_DISP_ROT_NONE);
+      lv_disp_set_direction(lv_disp_get_default(), 3);
     } else if (scrollDirection == FullRefreshDirections::RightAnim) {
-      lv_disp_set_rotation(lv_disp_get_default(), LV_DISP_ROT_NONE);
+      lv_disp_set_direction(lv_disp_get_default(), 5);
     } else if (scrollDirection == FullRefreshDirections::LeftAnim) {
-      lv_disp_set_rotation(lv_disp_get_default(), LV_DISP_ROT_NONE);
+      lv_disp_set_direction(lv_disp_get_default(), 4);
     }
   }
+  fullRefresh = true;
 }
-//
-//
-//void LittleVgl::DisplayDownScroll(){
-//  // We are controlling the drawing process, disable lvgl timers
-//  lv_timer_enable(false);
-//  
-//  // For each segment, draw the full width, 4 lines at a time starting from the bottom
-//  // TODO: Should probably calculate this from the size of the draw buffer
-//  int16_t height = 4;
-//  int16_t width = 240;
-//  int16_t y2 = 240;
-//  int16_t y1 = 240 - height;
-//  
-//  lv_area_t area;
-//  area.x1 = 0;
-//  area.x2 = width;
-//  
-//  // Start from the bottom and create a 4 line high box
-//  for (y1 = 240 - height; y1 >= 0; y1 -= height) {
-//    y2 = y1 + height - 1;
-//    
-//    // If the box has reached the end of the visible line on the lcd controller...
-//    if (y2 == visibleNbLines - 1) {
-//      // move past the non visible lines
-//      writeOffset += (totalNbLines - visibleNbLines);
-//      // and wrap around to the start of address space
-//      writeOffset %= totalNbLines;
-//    }
-//    // Set new box
-//    area.y1 = y1;
-//    area.y2 = y2;
-//    
-//    // Scroll as we draw
-//    uint16_t toScroll = height;
-//    if (scrollOffset >= toScroll)
-//      scrollOffset -= toScroll;
-//    else { // now we need to wrap the scroll address
-//      toScroll -= scrollOffset;
-//      scrollOffset = totalNbLines - toScroll;
-//    }
-//    lcd.VerticalScrollStartAddress(scrollOffset);
-//  
-//    lv_disp_t* disp = lv_disp_get_default();
-//    // Clear invalid area list / tells lvgl that nothing on the screen needs to be updated
-//    _lv_inv_area(disp, nullptr);
-//    // invalidate only the segment we want to update in this portion of the animation
-//    _lv_inv_area(disp, &area);
-//    // cancel any current flushes in the display driver
-//    // Since we've stopped timers, it will be waiting forever if there is currently a flush
-//    lv_disp_flush_ready(disp->driver);
-//    lv_refr_now(disp);
-//  }
-//  // Done! clear flags and enable timers
-//  scrollDirection = FullRefreshDirections::None;
-//  animating = false;
-//  lv_timer_enable(true);
-//}
-//
-//void LittleVgl::DisplayHorizAnim() {
-//  lv_timer_enable(false);
-//  
-//  int16_t height, width, x1, x2;
-//  lv_area_t area;
-//  
-//  height = 240;
-//  width = 4;
-//  int16_t (*NextStep)(int16_t, int16_t){};
-//  bool (*CheckEnd)(int16_t){};
-//  
-//  area.y1=0;
-//  area.y2=height;
-//
-//  if (scrollDirection == FullRefreshDirections::RightAnim) {
-//    x1 = 0;
-//
-//    CheckEnd = [](int16_t x) -> bool {
-//      return (x < LV_HOR_RES_MAX);
-//    };
-//    NextStep = [](int16_t x, int16_t width) -> int16_t {
-//      auto newx = x + width * 2;
-//      if (newx < 240) {return newx;};
-//      return (newx < 240 + width) ? (newx - 240 + width) : newx;
-//    };
-//
-//  } else if (scrollDirection == FullRefreshDirections::LeftAnim) {
-//    x1 = 240 - width;
-//
-//    CheckEnd = [](int16_t x) -> bool {
-//      return (x >= 0);
-//    };
-//    NextStep = [](int16_t x, int16_t width) -> int16_t {
-//      auto newx = x - width * 2;
-//      if (newx >= 0) {return newx;}
-//      return (newx >= 0 - width) ? (newx + 240 - width) : newx;
-//    };
-//
-//  } else {
-//    // Not set for a horizontal animation!
-//    lv_timer_enable(true);
-//    return;
-//  }
-//
-//  for (; CheckEnd(x1); x1 = NextStep(x1, width)) {
-//      x2 = x1 + width-1;
-//
-//      if (area.y2 == visibleNbLines - 1) {
-//        writeOffset += (totalNbLines - visibleNbLines);
-//        writeOffset %= totalNbLines;
-//      }
-//      area.x1 = x1;
-//      area.x2 = x2;
-//  
-//      lv_disp_t* disp = lv_disp_get_default();
-//      _lv_inv_area(disp, nullptr);
-//      _lv_inv_area(disp, &area);
-//      lv_disp_flush_ready(disp->driver);
-//      lv_refr_now(disp);
-//    }
-//  scrollDirection = FullRefreshDirections::None;
-//  animating = false;
-//  lv_timer_enable(true);
-//}
-//
-//void LittleVgl::FlushDisplayManually() {
-//  switch(scrollDirection){
-//    case FullRefreshDirections::Down:
-//      DisplayDownScroll();
-//      break;
-//    case FullRefreshDirections::RightAnim:
-//    case FullRefreshDirections::LeftAnim:
-//      DisplayHorizAnim();
-//      break;
-//    default:
-//      break;
-//  }
-//}
-//
+
 void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
 //  uint16_t y1, y2, width, height = 0;
 //
 //  ulTaskNotifyTake(pdTRUE, 200);
-//  // NOtification is still needed (even if there is a mutex on SPI) because of the DataCommand pin
-//  // which cannot be set/clear during a transfert.
-//  
-//  if (!animating && (scrollDirection == FullRefreshDirections::Down ||
-//                     scrollDirection == FullRefreshDirections::RightAnim ||
-//                     scrollDirection == FullRefreshDirections::LeftAnim)){
-//    animating = true;
-//    FlushDisplayManually();
-//    return;
-//  }
+//  // Notification is still needed (even if there is a mutex on SPI) because of the DataCommand pin
+//  // which cannot be set/clear during a transfer.
 //
-//  if ((scrollDirection == FullRefreshDirections::Up) && (area->y1 == 0)) {
+//  if ((scrollDirection == LittleVgl::FullRefreshDirections::Down) && (area->y2 == visibleNbLines - 1)) {
+//    writeOffset = ((writeOffset + totalNbLines) - visibleNbLines) % totalNbLines;
+//  } else if ((scrollDirection == FullRefreshDirections::Up) && (area->y1 == 0)) {
 //    writeOffset = (writeOffset + visibleNbLines) % totalNbLines;
 //  }
 //
@@ -241,13 +110,34 @@ void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
 //  width = (area->x2 - area->x1) + 1;
 //  height = (area->y2 - area->y1) + 1;
 //
-//  if (scrollDirection == FullRefreshDirections::Up) {
+//  if (scrollDirection == LittleVgl::FullRefreshDirections::Down) {
+//
+//    if (area->y2 < visibleNbLines - 1) {
+//      uint16_t toScroll = 0;
+//      if (area->y1 == 0) {
+//        toScroll = height * 2;
+//        scrollDirection = FullRefreshDirections::None;
+//        lv_disp_set_direction(lv_disp_get_default(), 0);
+//      } else {
+//        toScroll = height;
+//      }
+//
+//      if (scrollOffset >= toScroll)
+//        scrollOffset -= toScroll;
+//      else {
+//        toScroll -= scrollOffset;
+//        scrollOffset = (totalNbLines) -toScroll;
+//      }
+//      lcd.VerticalScrollStartAddress(scrollOffset);
+//    }
+//
+//  } else if (scrollDirection == FullRefreshDirections::Up) {
 //
 //    if (area->y1 > 0) {
 //      if (area->y2 == visibleNbLines - 1) {
 //        scrollOffset += (height * 2);
 //        scrollDirection = FullRefreshDirections::None;
-////        lv_disp_set_rotation(lv_disp_get_default(), LV_DISP_ROT_NONE);
+//        lv_disp_set_direction(lv_disp_get_default(), 0);
 //      } else {
 //        scrollOffset += height;
 //      }
@@ -257,12 +147,12 @@ void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
 //  } else if (scrollDirection == FullRefreshDirections::Left or scrollDirection == FullRefreshDirections::LeftAnim) {
 //    if (area->x2 == visibleNbLines - 1) {
 //      scrollDirection = FullRefreshDirections::None;
-////      lv_disp_set_rotation(lv_disp_get_default(), LV_DISP_ROT_NONE);
+//      lv_disp_set_direction(lv_disp_get_default(), 0);
 //    }
 //  } else if (scrollDirection == FullRefreshDirections::Right or scrollDirection == FullRefreshDirections::RightAnim) {
 //    if (area->x1 == 0) {
 //      scrollDirection = FullRefreshDirections::None;
-////      lv_disp_set_rotation(lv_disp_get_default(), LV_DISP_ROT_NONE);
+//      lv_disp_set_direction(lv_disp_get_default(), 0);
 //    }
 //  }
 //
@@ -319,9 +209,15 @@ bool LittleVgl::GetTouchPadInfo(lv_indev_data_t* ptr) {
   return false;
 }
 
-//void LittleVgl::InitTheme() {
-//  if (!lv_pinetime_theme_is_inited()) {
-//    lv_theme_t* th = lv_pinetime_theme_init(lv_disp_get_default(), lv_color_white(), lv_color_hex(0xC0C0C0), &jetbrains_mono_bold_20);
-//    lv_disp_set_theme(lv_disp_get_default(), th);
-//  }
-//}
+void LittleVgl::InitTheme() {
+
+  lv_theme_t* th = lv_pinetime_theme_init(LV_COLOR_WHITE,
+                                          LV_COLOR_SILVER,
+                                          0,
+                                          &jetbrains_mono_bold_20,
+                                          &jetbrains_mono_bold_20,
+                                          &jetbrains_mono_bold_20,
+                                          &jetbrains_mono_bold_20);
+
+  lv_theme_set_act(th);
+}

--- a/sim/displayapp/LittleVgl.h
+++ b/sim/displayapp/LittleVgl.h
@@ -25,27 +25,30 @@ namespace Pinetime {
       bool GetTouchPadInfo(lv_indev_data_t* ptr);
       void SetFullRefresh(FullRefreshDirections direction);
       void SetNewTouchPoint(uint16_t x, uint16_t y, bool contact);
-//
-//    private:
-//      void InitDisplay();
+
+      bool GetFullRefresh() {
+        bool returnValue = fullRefresh;
+        if (fullRefresh) {
+          fullRefresh = false;
+        }
+        return returnValue;
+      }
+
+    private:
+      void InitDisplay();
       void InitTouchpad();
-//      void InitTheme();
-//  
-//      void FlushDisplayManually();
-//      void DisplayDownScroll();
-//      void DisplayHorizAnim();
+      void InitTheme();
 
       Pinetime::Drivers::St7789& lcd;
       Pinetime::Drivers::Cst816S& touchPanel;
 
-//      lv_disp_draw_buf_t disp_buf_2;
-//      lv_color_t buf2_1[LV_HOR_RES_MAX * 4];
-//      lv_color_t buf2_2[LV_HOR_RES_MAX * 4];
-//
-      lv_disp_drv_t disp_drv;
-      lv_point_t previousClick;
+      lv_disp_buf_t disp_buf_2;
+      lv_color_t buf2_1[LV_HOR_RES_MAX * 4];
+      lv_color_t buf2_2[LV_HOR_RES_MAX * 4];
 
-      bool firstTouch = true;
+      lv_disp_drv_t disp_drv;
+
+      bool fullRefresh = false;
       static constexpr uint8_t nbWriteLines = 4;
       static constexpr uint16_t totalNbLines = 320;
       static constexpr uint16_t visibleNbLines = 240;


### PR DESCRIPTION
Move lvgl display init from main.cpp into LittleVgl.cpp to be closer to InfiniTime, where display initialization is also done in LitteVgl.cpp.

Enable the original FlushDisplay code to get the screen transition animations like on the real PineTime.

Also slow down the rendering, to actually be able to see the screen flushing.

For the Up and Down screen transitions implement the screen movement.
When moving Down, move the the whole screen content down, and then draw the new part of the new screen at the top of the display. Repeat until screen transition is finished.

Fixes: https://github.com/InfiniTimeOrg/InfiniSim/issues/13