### PR TITLE
cmake: support date submodule include dir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,7 +149,13 @@ target_include_directories(infinisim PRIVATE "${InfiniTime_DIR}/src/libs")
 target_include_directories(infinisim PRIVATE "lv_drivers")
 
 # add dates library
-target_include_directories(infinisim SYSTEM PRIVATE "${InfiniTime_DIR}/src/libs/date/includes")
+if(EXISTS "${InfiniTime_DIR}/src/libs/date/includes")
+  target_include_directories(infinisim SYSTEM PRIVATE "${InfiniTime_DIR}/src/libs/date/includes")
+elseif(EXISTS "${InfiniTime_DIR}/src/libs/date/include")
+  target_include_directories(infinisim SYSTEM PRIVATE "${InfiniTime_DIR}/src/libs/date/include")
+else()
+  message(FATAL_ERROR "can't find date includes/include directory, is the submodule checked out?")
+endif()
 
 # add Screens, fonts and icons with a globbing expression,
 # to enable easier CI test-runs for PRs adding new Screens/Fonts/Icons


### PR DESCRIPTION
Support both the current modified `date/includes` directory and the
`date` submodules `date/include` directory.

Once https://github.com/InfiniTimeOrg/InfiniTime/pull/1183 is merged
and the InfiniTime submodule is checked in also update the GitHub Action
and the AUR package.

Fixes: https://github.com/InfiniTimeOrg/InfiniSim/issues/42