### PR TITLE
Updated README with node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ For a history on how this simulator started and the challenges on its way visit 
 - CMake
 - SDL2 (provides the simulator window, handles mouse and keyboard input)
 - Compiler (g++ or clang++)
-- Node.js v12.0.0 or later for font generation with InfiniTime v1.10
 - [lv_font_conv](https://github.com/lvgl/lv_font_conv#install-the-script) (for `font.c` generation since [InfiniTime#1097](https://github.com/InfiniTimeOrg/InfiniTime/pull/1097))
+	- Note: requires Node.js v12.0.0 or later
 
 On Ubuntu/Debian install the following packages:
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ For a history on how this simulator started and the challenges on its way visit 
 - CMake
 - SDL2 (provides the simulator window, handles mouse and keyboard input)
 - Compiler (g++ or clang++)
+- Node.js v12.0.0 or later for font generation with InfiniTime v1.10
 - [lv_font_conv](https://github.com/lvgl/lv_font_conv#install-the-script) (for `font.c` generation since [InfiniTime#1097](https://github.com/InfiniTimeOrg/InfiniTime/pull/1097))
 
 On Ubuntu/Debian install the following packages:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ For a history on how this simulator started and the challenges on its way visit 
 - SDL2 (provides the simulator window, handles mouse and keyboard input)
 - Compiler (g++ or clang++)
 - [lv_font_conv](https://github.com/lvgl/lv_font_conv#install-the-script) (for `font.c` generation since [InfiniTime#1097](https://github.com/InfiniTimeOrg/InfiniTime/pull/1097))
-	- Note: requires Node.js v12.0.0 or later
+  - Note: requires Node.js v12.0.0 or later
 
 On Ubuntu/Debian install the following packages:
 


### PR DESCRIPTION
Updated the README with a working node.js version needed to build the project. My original version v10.19.0 wasn't able to build the fonts with the font generation changes in InfiniTime v1.10. Node.js v12.22.9 was tested and working on two of my own machines.