### PR TITLE
Support "Centralize most color definitions"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,8 +197,6 @@ target_sources(infinisim PUBLIC
   ${InfiniTime_DIR}/src/displayapp/Colors.cpp
   ${InfiniTime_DIR}/src/displayapp/DisplayApp.h
   ${InfiniTime_DIR}/src/displayapp/DisplayApp.cpp
-  ${InfiniTime_DIR}/src/displayapp/lv_pinetime_theme.h
-  ${InfiniTime_DIR}/src/displayapp/lv_pinetime_theme.c
   ${InfiniTime_DIR}/src/displayapp/icons/bg_clock.c # used by WatchFaceAnalog.cpp
   ${InfiniTime_DIR}/src/buttonhandler/ButtonHandler.h
   ${InfiniTime_DIR}/src/buttonhandler/ButtonHandler.cpp
@@ -231,6 +229,18 @@ target_sources(infinisim PUBLIC
   ${InfiniTime_DIR}/src/systemtask/SystemMonitor.cpp
 )
 
+if(EXISTS ${InfiniTime_DIR}/src/displayapp/InfiniTimeTheme.cpp)
+  target_compile_definitions(infinisim PUBLIC INFINITIME_THEME_CPP)
+  target_sources(infinisim PUBLIC
+    ${InfiniTime_DIR}/src/displayapp/InfiniTimeTheme.cpp
+    ${InfiniTime_DIR}/src/displayapp/InfiniTimeTheme.h
+)
+else()
+  target_sources(infinisim PUBLIC
+    ${InfiniTime_DIR}/src/displayapp/lv_pinetime_theme.h
+    ${InfiniTime_DIR}/src/displayapp/lv_pinetime_theme.c
+  )
+endif()
 
 # QCBOR
 add_library(QCBOR STATIC

--- a/main.cpp
+++ b/main.cpp
@@ -21,7 +21,11 @@
 #include "lv_drivers/indev/mousewheel.h"
 
 // get PineTime header
+#if defined(INFINITIME_THEME_CPP)
+#include "displayapp/InfiniTimeTheme.h"
+#else
 #include "displayapp/lv_pinetime_theme.h"
+#endif
 #include <drivers/Hrs3300.h>
 #include <drivers/Bma421.h>
 

--- a/sim/displayapp/LittleVgl.cpp
+++ b/sim/displayapp/LittleVgl.cpp
@@ -1,5 +1,9 @@
 #include "displayapp/LittleVgl.h"
+#if defined(INFINITIME_THEME_CPP)
+#include "displayapp/InfiniTimeTheme.h"
+#else
 #include "displayapp/lv_pinetime_theme.h"
+#endif
 
 #include <FreeRTOS.h>
 #include <task.h>


### PR DESCRIPTION
Support changes in InfiniTimeOrg/InfiniTime#1258

The file `lv_pinetime_theme.c` is renamed to `InfiniTimeTheme.cpp`.
Need to pick up that change in the simulator to compile with the new cpp
file if it exists.

Furthermore use the new `InfiniTimeTheme.h` header in simulator files.

Fixes: https://github.com/InfiniTimeOrg/InfiniSim/issues/49