### PR TITLE
Print memory usage (p/P) only on change

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -835,7 +835,10 @@ public:
       if (print_memory_usage) {
         // print free memory with the knowledge that 14KiB RAM is the actual PineTime-Memory
         lv_mem_monitor(&mem_mon);
-        printf("actual free_size = %d\n", int64_t(mem_mon.free_size) - (LV_MEM_SIZE - 14U*1024U));
+        if (mem_mon.free_size != mem_mon_last_free_size) {
+          printf("actual free_size = %d\n", int64_t(mem_mon.free_size) - (LV_MEM_SIZE - 14U*1024U));
+          mem_mon_last_free_size = mem_mon.free_size;
+        }
       }
       if (gif_manager.is_in_progress())
       {
@@ -882,6 +885,8 @@ private:
 
     bool left_release_sent = true; // make sure to send one mouse button release event
     bool right_last_state = false; // varable used to send message only on changing state
+
+    uint32_t mem_mon_last_free_size = LV_MEM_SIZE;
 
     GifManager gif_manager;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -832,14 +832,18 @@ public:
           lv_obj_del(screen_off_label);
         }
       }
+
       if (print_memory_usage) {
-        // print free memory with the knowledge that 14KiB RAM is the actual PineTime-Memory
         lv_mem_monitor(&mem_mon);
         if (mem_mon.free_size != mem_mon_last_free_size) {
-          printf("actual free_size = %d\n", int64_t(mem_mon.free_size) - (LV_MEM_SIZE - 14U*1024U));
+          uint32_t pinetime_lvgl_memory = 14U*1024U; // 14KiB is the LVGL memory size used in InfiniTime
+          uint32_t mem_used = LV_MEM_SIZE - int64_t(mem_mon.free_size);
+          int32_t mem_free = pinetime_lvgl_memory - mem_used;
+          printf("Mem: %u used (%+4d) %d free\n", mem_used, mem_mon_last_free_size - mem_mon.free_size, mem_free);
           mem_mon_last_free_size = mem_mon.free_size;
         }
       }
+
       if (gif_manager.is_in_progress())
       {
         gif_manager.write_frame();

--- a/main.cpp
+++ b/main.cpp
@@ -836,10 +836,14 @@ public:
       if (print_memory_usage) {
         lv_mem_monitor(&mem_mon);
         if (mem_mon.free_size != mem_mon_last_free_size) {
-          uint32_t pinetime_lvgl_memory = 14U*1024U; // 14KiB is the LVGL memory size used in InfiniTime
-          uint32_t mem_used = LV_MEM_SIZE - int64_t(mem_mon.free_size);
-          int32_t mem_free = pinetime_lvgl_memory - mem_used;
-          printf("Mem: %u used (%+4d) %d free\n", mem_used, mem_mon_last_free_size - mem_mon.free_size, mem_free);
+          // 14KiB is the LVGL memory size used in InfiniTime
+          constexpr uint32_t pinetime_lvgl_memory = 14U*1024U;
+          uint32_t mem_used = LV_MEM_SIZE - mem_mon.free_size;
+          // The "budget" value shows how much free lvgl memory the PineTime
+          // would have free and will go negative when more memory is used
+          // in the simulator than is available on the real hardware.
+          int32_t budget = pinetime_lvgl_memory - mem_used;
+          printf("Mem: %5u used (change: %+5d, peak: %5u) %d budget left\n", mem_used, mem_mon_last_free_size - mem_mon.free_size, mem_mon.max_used, budget);
           mem_mon_last_free_size = mem_mon.free_size;
         }
       }


### PR DESCRIPTION
No longer spam the memory usage constantly. This makes the output much more useful by allowing to observe each change in memory usage, since the values now no longer get pushed up and scroll out of view rapidly.

---

Print used memory (and change since last print) in addition to free memory.

Example output:
```
Mem: 4952 used (-248) 9384 free
Mem: 5960 used (+1008) 8376 free
Mem: 5992 used ( +32) 8344 free
Mem: 5720 used (-272) 8616 free
Mem: 5728 used (  +8) 8608 free
Mem: 5880 used (+152) 8456 free
Mem: 5728 used (-152) 8608 free
```