### PR TITLE
Update Notification::On/Off enum rename

### DIFF
--- a/littlefs-do-main.cpp
+++ b/littlefs-do-main.cpp
@@ -570,8 +570,9 @@ int command_settings(const std::string &program_name, const std::vector<std::str
   {
     auto notif = settingsController.GetNotificationStatus();
     auto notif_str = [](auto val) {
-      if (val == Settings::Notification::ON) return "ON";
-      if (val == Settings::Notification::OFF) return "OFF";
+      if (val == Settings::Notification::On) return "On";
+      if (val == Settings::Notification::Off) return "Off";
+      if (val == Settings::Notification::Sleep) return "Sleep";
       return "unknown";
     }(notif);
     std::cout << "NotificationStatus: " << static_cast<int>(notif) << " " << notif_str << std::endl;


### PR DESCRIPTION
In https://github.com/InfiniTimeOrg/InfiniTime/pull/1261 the enums for Notification ON/OFF were renamed to On/Off and the additional entry `Sleep` was added.

Update `littlefs-do` to this change.

Thanks @kieranc for finding this issue