### PR TITLE
Conditionally pass Controllers::FS to AlarmController to support save to file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -316,6 +316,13 @@ if(BUILD_RESOURCES)
   endif()
 endif()
 
+# check if AlarmController.h needs FileSystem member
+file(STRINGS "${InfiniTime_DIR}/src/components/alarm/AlarmController.h" alarmControllerFileSystemEntries REGEX "Controllers::FS")
+if(NOT alarmControllerFileSystemEntries STREQUAL "")
+  message(STATUS "detected AlarmController.h using 'Controllers::FS'")
+  set_source_files_properties(main.cpp PROPERTIES COMPILE_DEFINITIONS ALARMCONTROLLER_NEEDS_FS)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Special case for SDL2 dependency, goal is to find a config that exports SDL2::SDL2 target
 # libsdl2-dev has a `sdl2-config.cmake` that doesn't export this, but vcpkg does..

--- a/main.cpp
+++ b/main.cpp
@@ -354,7 +354,11 @@ Pinetime::Controllers::MotionController motionController;
 Pinetime::Controllers::TimerController timerController;
 #endif
 
+#if defined(ALARMCONTROLLER_NEEDS_FS)
+Pinetime::Controllers::AlarmController alarmController {dateTimeController, fs};
+#else
 Pinetime::Controllers::AlarmController alarmController {dateTimeController};
+#endif
 Pinetime::Controllers::TouchHandler touchHandler;
 Pinetime::Controllers::ButtonHandler buttonHandler;
 Pinetime::Controllers::BrightnessController brightnessController {};


### PR DESCRIPTION
Support for https://github.com/InfiniTimeOrg/InfiniTime/pull/1367 which is a rebase/improvement
of https://github.com/InfiniTimeOrg/InfiniTime/pull/1333 by @ght

The PR adds saving and restoring alarm state to the SPI NOR flash. So
the AlarmController needs the FileSystem-controller to work.

To support both the current `main` branch and the "save-alarm-to-file"
PR pass the Filesystem controller conditionally, only if
`Controller::FS` is mentioned in the `AlarmController.h` file