### PR TITLE
DisplayApp now takes the filesystem as ctor arguments

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -360,7 +360,8 @@ Pinetime::Applications::DisplayApp displayApp(lcd,
                                               timerController,
                                               alarmController,
                                               brightnessController,
-                                              touchHandler);
+                                              touchHandler,
+                                              fs);
 
 Pinetime::System::SystemTask systemTask(spi,
                                         lcd,


### PR DESCRIPTION
Since #1324 (https://github.com/InfiniTimeOrg/InfiniTime/pull/1324) / #1024 (https://github.com/InfiniTimeOrg/InfiniTime/pull/1024) DisplayApp needs the FileSystem as parameter to the constructor.