### PR TITLE
Add option BUILD_RESOURCES=ON to build resources for sim

### DIFF
--- a/.github/workflows/lv_sim.yml
+++ b/.github/workflows/lv_sim.yml
@@ -38,6 +38,12 @@ jobs:
         run:
           npm i -g lv_font_conv@1.5.2
 
+      - name: Install lv_img_conv
+        run: |
+          npm i -g ts-node@10.9.1 -g
+          npm i -g @swc/core -g
+          npm i -g lv_img_conv@0.3.0 -g
+
       #########################################################################################
       # Checkout
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,22 @@ if(EXISTS ${InfiniTime_DIR}/src/displayapp/fonts/CMakeLists.txt)
   target_link_libraries(infinisim PRIVATE infinitime_fonts)
 endif()
 
+option(BUILD_RESOURCES "Generate a resource.zip file to install to spi.raw file" ON)
+if(BUILD_RESOURCES)
+  if(EXISTS ${InfiniTime_DIR}/src/resources/CMakeLists.txt)
+    # set verison variables as used in resources/CMakeLists.txt
+    set(pinetime_VERSION_MAJOR ${PROJECT_VERSION_MAJOR})
+    set(pinetime_VERSION_MINOR ${PROJECT_VERSION_MINOR})
+    set(pinetime_VERSION_PATCH ${PROJECT_VERSION_PATCH})
+    # available since https://github.com/InfiniTimeOrg/InfiniTime/pull/1097
+    message(STATUS "add subdirectory ${InfiniTime_DIR}/src/resources for 'GenerateResources' target")
+    add_subdirectory(${InfiniTime_DIR}/src/resources resources)
+    add_dependencies(infinisim GenerateResources)
+  else()
+    message(FATAL_ERROR "BUILD_RESOURCES is enabled, but InfiniTime subdirectory has no resources/CMakeLists.txt file")
+  endif()
+endif()
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 # Special case for SDL2 dependency, goal is to find a config that exports SDL2::SDL2 target
 # libsdl2-dev has a `sdl2-config.cmake` that doesn't export this, but vcpkg does..

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ git submodule update --init --recursive
 - Compiler (g++ or clang++)
 - [lv_font_conv](https://github.com/lvgl/lv_font_conv#install-the-script) (for `font.c` generation since [InfiniTime#1097](https://github.com/InfiniTimeOrg/InfiniTime/pull/1097))
   - Note: requires Node.js v12.0.0 or later
+- [lv_img_conv](https://github.com/lvgl/lv_img_conv) (for `resource.zip` generation when `BUILD_RESOURCES=ON`, which is the default)
 
 On Ubuntu/Debian install the following packages:
 
@@ -55,6 +56,12 @@ Then install the `lv_font_conv` executable to the InfiniSim source directory (wi
 npm install lv_font_conv@1.5.2
 ```
 
+When you want to create a `resource.zip` file then install the `lv_img_conv` executable to the InfiniSim source directory (will be installed at `node_modules/.bin/lv_img_conv`)
+
+```sh
+npm install ts-node@10.9.1 @swc/core lv_img_conv@0.3.0
+```
+
 ## Configure and Build
 
 In the most basic configuration tell cmake to configure the project and build it with the following two commands:
@@ -70,6 +77,7 @@ The following configuration settings can be added to the first `cmake -S . -B bu
   Inside that directory the `src/libs/lvgl` submodule must be checked out as well.
   The default value points to the InfiniTime submodule in this repository.
 - `-DMONITOR_ZOOM=1`: scale simulator window by this factor
+- `-DBUILD_RESOURCES=ON`: enable/disable `resource.zip` creation, will be created in the `<build-dir>/resources` folder
 
 ## Run Simulator
 


### PR DESCRIPTION
The `BUILD_RESOURCES` option is also available in `InfiniTime`, but we don't want to require building the firmware to test `resource.zip` file generation.