### PR TITLE
Add support for low battery warning

### DIFF
--- a/sim/components/battery/BatteryController.h
+++ b/sim/components/battery/BatteryController.h
@@ -21,6 +21,10 @@ namespace Pinetime {
         return voltage;
       }
 
+      bool BatteryIsLow() const {
+        return false;
+      }
+
       bool IsCharging() const {
         // isCharging will go up and down when fully charged
         // isFull makes sure this returns false while fully charged.

--- a/sim/components/battery/BatteryController.h
+++ b/sim/components/battery/BatteryController.h
@@ -22,7 +22,7 @@ namespace Pinetime {
       }
 
       bool BatteryIsLow() const {
-        return false;
+        return percentRemaining <= lowBatteryThreshold;
       }
 
       bool IsCharging() const {
@@ -52,6 +52,8 @@ namespace Pinetime {
 
       //void SaadcEventHandler(nrfx_saadc_evt_t const* p_event);
       //static void AdcCallbackStatic(nrfx_saadc_evt_t const* event);
+
+      static constexpr uint8_t lowBatteryThreshold {20};
 
       bool isReading = false;
 


### PR DESCRIPTION
I implemented a [low battery warning](https://github.com/InfiniTimeOrg/InfiniTime/pull/1352) and this little change should fix the problem with the simulator build. It is just a dummy function that always reports enough battery since the whole BatteryController seems to do nothing.