### PR TITLE
Enable CMake Unity build

### DIFF
--- a/.github/workflows/lv_sim.yml
+++ b/.github/workflows/lv_sim.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: CMake
         run:  |
-          cmake -G Ninja -S . -B build_lv_sim
+          cmake -G Ninja -S . -B build_lv_sim -DCMAKE_UNITY_BUILD=ON
 
       #########################################################################################
       # Build and Upload simulator

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,14 @@ file(GLOB InfiniTime_SCREENS
   "${InfiniTime_DIR}/src/displayapp/screens/settings/*.h"
   "${InfiniTime_DIR}/src/displayapp/screens/settings/*.cpp"
 )
+
+# skip files, which currently cause problems when turning on CMake untiy build
+set_source_files_properties(
+  main.cpp
+  ${LVGL_SOURCES}
+  ${InfiniTime_SCREENS}
+  PROPERTIES SKIP_UNITY_BUILD_INCLUSION ON)
+
 file(GLOB InfiniTime_FONTS
   "${InfiniTime_DIR}/src/displayapp/fonts/*.c"
 )


### PR DESCRIPTION
This PR turns on CMake unity build in the CI.

Some files cause problems with the unity build. This is why I added the `SKIP_UNITY_BUILD_INCLUSION` property to those files.

On my machine the unity build takes about 7s, whereas the normal build takes about 9.5s. In the current GitHub workflow the build takes about 1 minute. So there the seed up might be nice.

The unity build infinisim executable is also just 9.5MB, whereas the normal build is about 11MB.  