### PR TITLE
Infinisim: GifExporter: Disable dithering

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -230,7 +230,7 @@ public:
           image[(hi * sdl_width + wi)*4 + 3] = 255; // no alpha
         }
       }
-      GifWriteFrame(&writer, image.data(), sdl_width, sdl_height, delay_ds, 8, true);
+      GifWriteFrame(&writer, image.data(), sdl_width, sdl_height, delay_ds, 8, false);
     }
   }
   void close()


### PR DESCRIPTION
This patch disables dithering since it causes artifacts within the generated gif files.

Before:
![InfiniSim_2022-11-21_185255](https://user-images.githubusercontent.com/5813055/203137133-52a23a66-20d1-4d86-80bf-2e4690f87134.gif)

After:
![InfiniSim_2022-11-21_185433](https://user-images.githubusercontent.com/5813055/203137169-2d22a6ed-cb52-422a-ad53-c018beed959f.gif)
