### PR TITLE
Fix for enum watch faces

### DIFF
--- a/littlefs-do-main.cpp
+++ b/littlefs-do-main.cpp
@@ -535,15 +535,15 @@ int command_settings(const std::string &program_name, const std::vector<std::str
   settingsController.Init();
   using namespace Pinetime::Controllers;
   {
-    auto clockface = settingsController.GetClockFace();
+    auto clockface = settingsController.GetWatchFace();
     auto clockface_str = [](auto val) {
-      if (val == 0) return "Digital";
-      if (val == 1) return "Analog";
-      if (val == 2) return "PineTimeStyle";
-      if (val == 3) return "Terminal";
+      if (val == Pinetime::Applications::WatchFace::Digital) return "Digital";
+      if (val == Pinetime::Applications::WatchFace::Analog) return "Analog";
+      if (val == Pinetime::Applications::WatchFace::PineTimeStyle) return "PineTimeStyle";
+      if (val == Pinetime::Applications::WatchFace::Terminal) return "Terminal";
       return "unknown";
     }(clockface);
-    std::cout << "ClockFace: " << static_cast<int>(clockface) << " " << clockface_str << std::endl;
+    std::cout << "ClockFace: " << static_cast<uint32_t>(clockface) << " " << clockface_str << std::endl;
   }
   {
     auto chimes = settingsController.GetChimeOption();

--- a/main.cpp
+++ b/main.cpp
@@ -755,15 +755,15 @@ public:
     void switch_to_screen(uint8_t screen_idx)
     {
       if (screen_idx == 1) {
-        settingsController.SetClockFace(0);
+        settingsController.SetWatchFace(Pinetime::Applications::WatchFace::Digital);
         displayApp.StartApp(Pinetime::Applications::Apps::Clock, Pinetime::Applications::DisplayApp::FullRefreshDirections::None);
       }
       else if (screen_idx == 2) {
-        settingsController.SetClockFace(1);
+        settingsController.SetWatchFace(Pinetime::Applications::WatchFace::Analog);
         displayApp.StartApp(Pinetime::Applications::Apps::Clock, Pinetime::Applications::DisplayApp::FullRefreshDirections::None);
       }
       else if (screen_idx == 3) {
-        settingsController.SetClockFace(2);
+        settingsController.SetWatchFace(Pinetime::Applications::WatchFace::PineTimeStyle);
         displayApp.StartApp(Pinetime::Applications::Apps::Clock, Pinetime::Applications::DisplayApp::FullRefreshDirections::None);
       }
       else if (screen_idx == 4) {


### PR DESCRIPTION
This fixed the build errors for my [PR](https://github.com/InfiniTimeOrg/InfiniTime/pull/1339) at InfiniTime that introduces an enum for the watch faces. I guess both should be merged together because this one here would break with the current develop without the enum.

I get another error when building with resources enabled so I could not test that part.

The changes also look incomplete in that they do not touch all current watch faces.