### PR TITLE
timers: Fix restarting timer from a timer

### DIFF
--- a/sim/timers.cpp
+++ b/sim/timers.cpp
@@ -6,11 +6,11 @@ uint32_t timer_callback_wrapper(uint32_t interval, void *param) {
   if (!xTimer->running) {
     return 0;
   }
+  xTimer->running = false;
   xTimer->pxCallbackFunction(*xTimer);
   if (xTimer->auto_reload) {
     return xTimer->timer_period_in_ms;
   }
-  xTimer->running = false;
   return 0; // cancel timer
 }
 


### PR DESCRIPTION
Running xTimerChangePeriod and xTimerStart on the expired timer from a callback function returns successfully, but doesn't actually set the timer.

This bug causes this code to behave differently in the simulator than the watch.
https://github.com/Riksu9000/InfiniTime/commit/e16e889e0c17ab8c772bdb13b002962ef5391b61