### PR TITLE
Remove LVGL instance in main

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -341,8 +341,6 @@ Pinetime::Controllers::FS fs {spiNorFlash};
 Pinetime::Controllers::Settings settingsController {fs};
 Pinetime::Controllers::MotorController motorController {};
 
-Pinetime::Components::LittleVgl lvgl {lcd, fs};
-
 Pinetime::Controllers::DateTime dateTimeController {settingsController};
 Pinetime::Drivers::Watchdog watchdog;
 Pinetime::Controllers::NotificationManager notificationManager;
@@ -417,8 +415,6 @@ public:
         }
         motorController.Init();
         settingsController.Init();
-
-        lvgl.Init();
 
         lv_mem_monitor(&mem_mon);
         printf("initial free_size = %u\n", mem_mon.free_size);


### PR DESCRIPTION
This has been moved to DisplayApp in InfiniTime, so there were two instances in InfiniSim.

Fixes scrolling direction issue.

https://github.com/InfiniTimeOrg/InfiniTime/commit/6f942e20ed5881e0b520f4c4f0f1fd2ffb4a3a2b