### PR TITLE
Fix for the new analog watch face implementation in InfiniTime

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,6 @@ target_sources(infinisim PUBLIC
   ${InfiniTime_DIR}/src/displayapp/Colors.cpp
   ${InfiniTime_DIR}/src/displayapp/DisplayApp.h
   ${InfiniTime_DIR}/src/displayapp/DisplayApp.cpp
-  ${InfiniTime_DIR}/src/displayapp/icons/bg_clock.c # used by WatchFaceAnalog.cpp
   ${InfiniTime_DIR}/src/buttonhandler/ButtonHandler.h
   ${InfiniTime_DIR}/src/buttonhandler/ButtonHandler.cpp
   ${InfiniTime_DIR}/src/components/alarm/AlarmController.h


### PR DESCRIPTION
The new analog watch face implementation in InfiniTime draws the background programmatically instead of using a background picture. This branch removes this background picture from the files needed by cmake to build the project.

This PR must be merged after https://github.com/InfiniTimeOrg/InfiniTime/pull/1824.