### PR TITLE
Remove libpng submodule and require system lib

### DIFF
--- a/.github/workflows/lv_sim.yml
+++ b/.github/workflows/lv_sim.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Install cmake
         uses: lukka/get-cmake@v3.18.3
 
-      - name: Install SDL2 development package
+      - name: Install SDL2 and libpng development package
         run:  |
           sudo apt-get update
-          sudo apt-get -y install libsdl2-dev
+          sudo apt-get -y install libsdl2-dev libpng-dev
 
       - name: Install lv_font_conv
         run:

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "lv_drivers"]
 	path = lv_drivers
 	url = ../../lvgl/lv_drivers.git
-[submodule "libpng"]
-	path = libpng
-	url = ../../glennrp/libpng.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,11 +317,9 @@ configure_file("${InfiniTime_DIR}/src/Version.h.in" "${CMAKE_CURRENT_BINARY_DIR}
 
 option(WITH_PNG "Compile with libpng support to dump current screen as png" ON)
 if(WITH_PNG)
+  find_package(PNG REQUIRED)
   target_compile_definitions(infinisim PRIVATE WITH_PNG)
-  add_subdirectory(libpng EXCLUDE_FROM_ALL)
-  target_include_directories(infinisim PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
-  target_include_directories(infinisim PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/libpng")
-  target_link_libraries(infinisim PRIVATE png_static)
+  target_link_libraries(infinisim PRIVATE PNG::PNG)
 endif()
 
 target_include_directories(infinisim PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/gif-h")

--- a/README.md
+++ b/README.md
@@ -31,23 +31,24 @@ git submodule update --init --recursive
 - [lv_font_conv](https://github.com/lvgl/lv_font_conv#install-the-script) (for `font.c` generation since [InfiniTime#1097](https://github.com/InfiniTimeOrg/InfiniTime/pull/1097))
   - Note: requires Node.js v12.0.0 or later
 - [lv_img_conv](https://github.com/lvgl/lv_img_conv) (for `resource.zip` generation when `BUILD_RESOURCES=ON`, which is the default)
+- optional: `libpng`, see `-DWITH_PNG=ON` cmake setting below for more info
 
 On Ubuntu/Debian install the following packages:
 
 ```sh
-sudo apt install -y cmake libsdl2-dev g++ npm
+sudo apt install -y cmake libsdl2-dev g++ npm libpng-dev
 ```
 
 On Arch Linux the following packages are needed:
 
 ```sh
-sudo pacman -S cmake sdl2 gcc npm
+sudo pacman -S cmake sdl2 gcc npm libpng
 ```
 
 On Fedora the following packages are needed:
 
 ```sh
-sudo dnf install cmake SDL2-devel gcc zlib-devel npm
+sudo dnf install cmake SDL2-devel g++ npm patch perl libpng-devel
 ```
 
 Then install the `lv_font_conv` executable to the InfiniSim source directory (will be installed at `node_modules/.bin/lv_font_conv`)
@@ -78,6 +79,10 @@ The following configuration settings can be added to the first `cmake -S . -B bu
   The default value points to the InfiniTime submodule in this repository.
 - `-DMONITOR_ZOOM=1`: scale simulator window by this factor
 - `-DBUILD_RESOURCES=ON`: enable/disable `resource.zip` creation, will be created in the `<build-dir>/resources` folder
+- `-DWITH_PNG=ON`: enable/disable the screenshot to `PNG` support.
+  Per default InfiniSim tries to use `libpng` to create screenshots in PNG format.
+  This requires `libpng` development libraries as build and runtime dependency.
+  Can be disabled with cmake config setting `-DWITH_PNG=OFF`.
 
 ## Run Simulator
 

--- a/main.cpp
+++ b/main.cpp
@@ -65,7 +65,7 @@
 #include <chrono>
 #include <ctime>   // localtime
 #if defined(WITH_PNG)
-#include <libpng/png.h>
+#include <png.h>
 #endif
 #include <gif.h>
 


### PR DESCRIPTION
On rolling distros the usage of `libpng` submodule makes problems as the `zlib` system dependency of said module gets updated. Then the submodule regularly is too old to handle the updates `zlib` dependency.

Fix this maintenance churn by requiring `libpng` as system library as well. Then the distros package manager keeps those versions in sync.

This unfortunately requires users to install a new runtime/build dependency, but it still can be disabled with `-DWITH_PNG=OFF`.