### PR TITLE
Node v14 required for lv_font_conv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,6 +268,20 @@ set_target_properties(QCBOR PROPERTIES LINKER_LANGUAGE C)
 #        )
 target_link_libraries(infinisim PRIVATE QCBOR)
 
+# check version number of installed node package for minimum required
+find_program(NODE_EXE "node" NO_CACHE QUIET)
+if(NODE_EXE)
+  exec_program("${NODE_EXE}" ARGS "--version" OUTPUT_VARIABLE NODE_VERSION)
+  string(REPLACE "v" "" NODE_VERSION "${NODE_VERSION}")
+  if(NODE_VERSION VERSION_LESS 14.0.0)
+    message(WARNING "Node version v${NODE_VERSION} is less than required 14+, you will probably encounter build errors")
+  else()
+    message(STATUS "Founde node version v${NODE_VERSION}")
+  endif()
+else()
+  message(STATUS "Didn't find executable 'node' in path to check its version number")
+endif()
+
 if(EXISTS ${InfiniTime_DIR}/src/displayapp/fonts/CMakeLists.txt)
   # available since https://github.com/InfiniTimeOrg/InfiniTime/pull/1097
   message(STATUS "add subdirectory ${InfiniTime_DIR}/src/displayapp/fonts for 'infinitime_fonts' target")

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ git submodule update --init --recursive
 - SDL2 (provides the simulator window, handles mouse and keyboard input)
 - Compiler (g++ or clang++)
 - [lv_font_conv](https://github.com/lvgl/lv_font_conv#install-the-script) (for `font.c` generation since [InfiniTime#1097](https://github.com/InfiniTimeOrg/InfiniTime/pull/1097))
-  - Note: requires Node.js v12.0.0 or later
+  - Note: requires Node.js v14.0.0 or later
 - [lv_img_conv](https://github.com/lvgl/lv_img_conv) (for `resource.zip` generation when `BUILD_RESOURCES=ON`, which is the default)
 - optional: `libpng`, see `-DWITH_PNG=ON` cmake setting below for more info
 


### PR DESCRIPTION
The current readme of the `lv_font_conv` the minimum node.js version is
v14+. Update our readme to mention that minimum version as well.

And in CMake issue a warning if the detected node version is less than `v14.0`

Fixes: https://github.com/InfiniTimeOrg/InfiniSim/issues/109