### PR TITLE
Adjust NimbleController for changes in InfiniTime

### DIFF
--- a/sim/components/ble/NimbleController.cpp
+++ b/sim/components/ble/NimbleController.cpp
@@ -30,7 +30,8 @@ NimbleController::NimbleController(Pinetime::System::SystemTask& systemTask,
                                    Pinetime::Drivers::SpiNorFlash& spiNorFlash,
                                    Controllers::HeartRateController& heartRateController,
                                    Controllers::MotionController& motionController,
-                                   Controllers::FS& fs)
+                                   Controllers::FS& fs,
+                                   Controllers::Settings& settingsController)
   : systemTask {systemTask},
     bleController {bleController},
     dateTimeController {dateTimeController},

--- a/sim/components/ble/NimbleController.h
+++ b/sim/components/ble/NimbleController.h
@@ -53,7 +53,8 @@ namespace Pinetime {
                        Pinetime::Drivers::SpiNorFlash& spiNorFlash,
                        Controllers::HeartRateController& heartRateController,
                        Controllers::MotionController& motionController,
-                       Pinetime::Controllers::FS& fs);
+                       Pinetime::Controllers::FS& fs,
+                       Controllers::Settings& settingsController);
       void Init();
       void StartAdvertising();
 //      int OnGAPEvent(ble_gap_event* event);


### PR DESCRIPTION
Adjust NimbleController constructor for "Setting to disable DFU and FS access" in InfiniTime.

This is accompanying PR for https://github.com/InfiniTimeOrg/InfiniTime/pull/1891

This will **not** build against InfiniTime `main` branch, this will build against code in https://github.com/InfiniTimeOrg/InfiniTime/pull/1891