### PR TITLE
User application selection with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,13 @@ if(EXISTS ${InfiniTime_DIR}/src/displayapp/fonts/CMakeLists.txt)
   target_link_libraries(infinisim PRIVATE infinitime_fonts)
 endif()
 
+if(EXISTS ${InfiniTime_DIR}/src/displayapp/apps/CMakeLists.txt)
+  # available since https://github.com/InfiniTimeOrg/InfiniTime/pull/1928
+  message(STATUS "add subdirectory ${InfiniTime_DIR}/src/displayapp/apps for 'infinitime_apps' target")
+  add_subdirectory(${InfiniTime_DIR}/src/displayapp/apps displayapp/apps)
+  target_link_libraries(infinisim PRIVATE infinitime_apps)
+endif()
+
 option(BUILD_RESOURCES "Generate a resource.zip file to install to spi.raw file" ON)
 if(BUILD_RESOURCES)
   if(EXISTS ${InfiniTime_DIR}/src/resources/CMakeLists.txt)

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ The following configuration settings can be added to the first `cmake -S . -B bu
   Per default InfiniSim tries to use `libpng` to create screenshots in PNG format.
   This requires `libpng` development libraries as build and runtime dependency.
   Can be disabled with cmake config setting `-DWITH_PNG=OFF`.
+- `-DENABLE_USERAPPS`: ordered list of user applications to build into InfiniTime.
+  Values must be fields from the enumeration `Pinetime::Applications::Apps` and must be separated by a comma.
+  Ex: `-DENABLE_USERAPPS="Apps::Timer, Apps::Alarm"`.
+  The default list of user applications will be selected if this variable is not set.
 
 ## Run Simulator
 


### PR DESCRIPTION
Integrate the new infinitime_apps library and enable user applications selection using the CMake variable ENABLE_USERAPPS.