### PR TITLE
Update README with Ubuntu command to install python3-pil 

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ On OpenSUSE (Tumbleweed)
 
 ```sh
 sudo zypper install python311-Pillow
-
 ```
 
 ## Configure and Build

--- a/README.md
+++ b/README.md
@@ -73,9 +73,17 @@ pip install wheel Pillow
 
 Optionally, depending on your distro, it may also serve the Pip package as official native installation packages:
 
+On Ubuntu/Debian 
+
 ```sh
-# OpenSUSE Tumbleweed
+sudo apt install python3-pil
+```
+
+On OpenSUSE (Tumbleweed) 
+
+```sh
 sudo zypper install python311-Pillow
+
 ```
 
 ## Configure and Build


### PR DESCRIPTION
Added to the README file the Ubuntu command to install the python3-pil package. 
It was necessary on Ubuntu for me to successfully build the software.