### PR TITLE
fixes for Always On Display and SPI flash ID

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -376,7 +376,8 @@ Pinetime::Applications::DisplayApp displayApp(lcd,
                                               alarmController,
                                               brightnessController,
                                               touchHandler,
-                                              fs);
+                                              fs,
+                                              spiNorFlash);
 
 Pinetime::System::SystemTask systemTask(spi,
                                         spiNorFlash,

--- a/sim/components/brightness/BrightnessController.h
+++ b/sim/components/brightness/BrightnessController.h
@@ -6,7 +6,7 @@ namespace Pinetime {
   namespace Controllers {
     class BrightnessController {
     public:
-      enum class Levels { Off, Low, Medium, High };
+      enum class Levels { Off, AlwaysOn, Low, Medium, High };
       void Init();
 
       void Set(Levels level);

--- a/sim/drivers/SpiNorFlash.cpp
+++ b/sim/drivers/SpiNorFlash.cpp
@@ -26,7 +26,7 @@ SpiNorFlash::~SpiNorFlash() {
 }
 
 void SpiNorFlash::Init() {
-  device_id = ReadIdentificaion();
+  device_id = ReadIdentification();
   NRF_LOG_INFO(
     "[SpiNorFlash] Manufacturer : %d, Memory type : %d, memory density : %d", device_id.manufacturer, device_id.type, device_id.density);
 }
@@ -42,7 +42,7 @@ void SpiNorFlash::Wakeup() {
   NRF_LOG_INFO("[SpiNorFlash] Wakeup")
 }
 
-SpiNorFlash::Identification SpiNorFlash::ReadIdentificaion() {
+SpiNorFlash::Identification SpiNorFlash::ReadIdentification() {
   return {};
 }
 
@@ -89,6 +89,10 @@ bool SpiNorFlash::ProgramFailed() {
 
 bool SpiNorFlash::EraseFailed() {
   return false;
+}
+
+SpiNorFlash::Identification SpiNorFlash::GetIdentification() const {
+  return device_id;
 }
 
 void SpiNorFlash::Write(uint32_t address, const uint8_t* buffer, size_t size) {

--- a/sim/drivers/SpiNorFlash.h
+++ b/sim/drivers/SpiNorFlash.h
@@ -21,7 +21,6 @@ namespace Pinetime {
         uint8_t density = 0;
       };
 
-      Identification ReadIdentificaion();
       uint8_t ReadStatusRegister();
       bool WriteInProgress();
       bool WriteEnabled();
@@ -34,6 +33,8 @@ namespace Pinetime {
       bool ProgramFailed();
       bool EraseFailed();
 
+      Identification GetIdentification() const;
+
       void Init();
       void Uninit();
 
@@ -41,6 +42,8 @@ namespace Pinetime {
       void Wakeup();
 
     private:
+      Identification ReadIdentification();
+
       enum class Commands : uint8_t {
         PageProgram = 0x02,
         Read = 0x03,

--- a/sim/nrfx/hal/nrf_gpio.cpp
+++ b/sim/nrfx/hal/nrf_gpio.cpp
@@ -52,4 +52,7 @@ void nrfx_gpiote_in_init(uint32_t pin_number, nrfx_gpiote_in_config_t *config, n
 void nrfx_gpiote_in_event_enable(uint32_t pin_number, bool enable) {}
 void nrf_gpio_cfg_sense_input(uint32_t pin_number, nrf_gpio_pin_pull_t pin_pull, nrf_gpio_pin_sense_t sense) {}
 
+bool nrfx_gpiote_is_init() { return true; }
+void nrfx_gpiote_init() {}
+
 void APP_GPIOTE_INIT(uint32_t max_users) {}

--- a/sim/nrfx/hal/nrf_gpio.h
+++ b/sim/nrfx/hal/nrf_gpio.h
@@ -145,6 +145,9 @@ void nrfx_gpiote_in_init(uint32_t pin_number, nrfx_gpiote_in_config_t *config, n
 void nrfx_gpiote_in_event_enable(uint32_t pin_number, bool enable);
 void nrf_gpio_cfg_sense_input(uint32_t pin_number, nrf_gpio_pin_pull_t pin_pull, nrf_gpio_pin_sense_t sense);
 
+bool nrfx_gpiote_is_init();
+void nrfx_gpiote_init();
+
 void APP_GPIOTE_INIT(uint32_t max_users);
 
 #endif // NRF_GPIO_H__

--- a/sim/portmacro_cmsis.h
+++ b/sim/portmacro_cmsis.h
@@ -29,6 +29,16 @@
 #ifndef PORTMACRO_CMSIS_H
 #define PORTMACRO_CMSIS_H
 
+// ########## macro taken from app_util.h
+/**@brief Macro for performing rounded integer division (as opposed to truncating the result).
+ *
+ * @param[in]   A   Numerator.
+ * @param[in]   B   Denominator.
+ *
+ * @return      Rounded (integer) result of dividing A by B.
+ */
+#define ROUNDED_DIV(A, B) (((A) + ((B) / 2)) / (B))
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This introduces the necessary changes to deal with the changes introduced by the recent always on display and SPI JEDEC ID related commits to InfiniTime