### PR TITLE
feat: Introduce Flake for development and builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).defaultNix

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,42 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1725634671,
+        "narHash": "sha256-v3rIhsJBOMLR8e/RNWxr828tB+WywYIoajrZKFM+0Gg=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "574d1eac1c200690e27b8eb4e24887f8df7ac27c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,73 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+    flake-compat.url = "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz";
+  };
+
+  outputs = { self, ... }@inputs:
+    let
+      forAllSystems = function:
+        inputs.nixpkgs.lib.genAttrs [
+          "x86_64-linux"
+          "aarch64-linux"
+        ]
+          (system: function (import inputs.nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+          }));
+    in
+    {
+      packages = forAllSystems (pkgs:
+        with pkgs; {
+          default = stdenv.mkDerivation {
+            name = "infinisim";
+            src = pkgs.lib.cleanSource ./.;
+
+            nativeBuildInputs = [
+              cmake
+              git
+              libpng
+              nodePackages.lv_font_conv
+              patch
+              python3
+              python3.pkgs.pillow
+              SDL2
+              zlib
+            ];
+
+            postPatch = ''
+              # /usr/bin/env is not available in the build sandbox
+              substituteInPlace img/convert_bmp_to_header.py --replace "/usr/bin/env python3" "${python3}/bin/python3"
+            '';
+
+            cmakeFlags = [
+              ''-DBUILD_DFU=1''
+              ''-DBUILD_RESOURCES=1''
+            ];
+          };
+        });
+
+      devShells = forAllSystems (pkgs:
+        {
+          default =
+            pkgs.buildFHSUserEnv {
+              name = "infinitime-devenv";
+              # build tools
+              targetPkgs = pkgs: (with pkgs; [
+                cmake
+                git
+                libpng
+                nodePackages.lv_font_conv
+                patch
+                python3
+                python3.pkgs.pillow
+                SDL2
+                zlib
+              ]);
+            };
+        });
+    };
+}
+      

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,10 @@
+(import
+  (
+    let lock = builtins.fromJSON (builtins.readFile ./flake.lock); in
+    fetchTarball {
+      url = lock.nodes.flake-compat.locked.url or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  { src = ./.; }
+).shellNix


### PR DESCRIPTION
This PR introduces a Nix flake, allowing for InfiniSim to be built as a Flake, including a FHS development environment.

We also introduce `flake-compat`, allowing for non-Flake Nix mahcines to use the project as-is, both for building (`default.nix`), and development (`shell.nix`).

Additionally, we introduce `.envrc`, meaning that with `direnv`, the Nix Flake is activated automatically.