### PR TITLE
Support WakeLock.h for doNotGoToSleep Refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,13 @@ else()
   )
 endif()
 
+if(EXISTS ${InfiniTime_DIR}/src/systemtask/WakeLock.h)
+  target_sources(infinisim PUBLIC
+    ${InfiniTime_DIR}/src/systemtask/WakeLock.h
+    ${InfiniTime_DIR}/src/systemtask/WakeLock.cpp
+  )
+endif()
+
 # littlefs
 add_library(littlefs STATIC
   ${InfiniTime_DIR}/src/libs/littlefs/lfs_util.h


### PR DESCRIPTION
For InfiniTime PR https://github.com/InfiniTimeOrg/InfiniTime/pull/2107 a new systemtask file is introduced `WakeLock.h` and `WakeLock.cpp`.

If available add those files to the build target to support the current `main` and the new `WakeLock` using redesign.