### PR TITLE
sim: LittleVgl: add new function ClearTouchState for PR #2108

### DIFF
--- a/sim/displayapp/LittleVgl.cpp
+++ b/sim/displayapp/LittleVgl.cpp
@@ -220,10 +220,6 @@ void MoveScreen(lv_disp_drv_t *disp_drv, int16_t height) {
 void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
   uint16_t y1, y2, width, height = 0;
 
-  //ulTaskNotifyTake(pdTRUE, 200);
-  // Notification is still needed (even if there is a mutex on SPI) because of the DataCommand pin
-  // which cannot be set/clear during a transfer.
-
   //if ((scrollDirection == LittleVgl::FullRefreshDirections::Down) && (area->y2 == visibleNbLines - 1)) {
   //  writeOffset = ((writeOffset + totalNbLines) - visibleNbLines) % totalNbLines;
   //} else if ((scrollDirection == FullRefreshDirections::Up) && (area->y1 == 0)) {
@@ -296,7 +292,6 @@ void LittleVgl::FlushDisplay(const lv_area_t* area, lv_color_t* color_p) {
     if (height > 0) {
       //lcd.DrawBuffer(area->x1, y1, width, height, reinterpret_cast<const uint8_t*>(color_p), width * height * 2);
       DrawBuffer(&disp_drv, area->x1, y1, width, height, reinterpret_cast<uint8_t*>(color_p), width * height * 2);
-      //ulTaskNotifyTake(pdTRUE, 100);
     }
 
     uint16_t pixOffset = width * height;
@@ -341,11 +336,20 @@ void LittleVgl::SetNewTouchPoint(int16_t x, int16_t y, bool contact) {
   }
 }
 
+// Cancel an ongoing tap
+// Signifies that LVGL should not handle the current tap
 void LittleVgl::CancelTap() {
   if (tapped) {
     isCancelled = true;
     touchPoint = {-1, -1};
   }
+}
+
+// Clear the current tapped state
+// Signifies that touch input processing is suspended
+void LittleVgl::ClearTouchState() {
+  touchPoint = {-1, -1};
+  tapped = false;
 }
 
 bool LittleVgl::GetTouchPadInfo(lv_indev_data_t* ptr) {

--- a/sim/displayapp/LittleVgl.h
+++ b/sim/displayapp/LittleVgl.h
@@ -26,6 +26,7 @@ namespace Pinetime {
       void SetFullRefresh(FullRefreshDirections direction);
       void SetNewTouchPoint(int16_t x, int16_t y, bool contact);
       void CancelTap();
+      void ClearTouchState();
 
       bool GetFullRefresh() {
         bool returnValue = fullRefresh;


### PR DESCRIPTION
Add function `LittleVgl::ClearTouchState` introduced with https://github.com/InfiniTimeOrg/InfiniTime/pull/2108

As it is a new function the change is compatible with current v1.14.0-dev state (`main` branch of InfiniTime)