### PR TITLE
cmake: remove unused QCBOR cmake code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,31 +265,6 @@ add_library(littlefs STATIC
 target_include_directories(littlefs PUBLIC "${InfiniTime_DIR}/src/libs/littlefs")
 target_link_libraries(infinisim PRIVATE littlefs)
 
-# QCBOR
-add_library(QCBOR STATIC
-  ${InfiniTime_DIR}/src/libs/QCBOR/src/ieee754.c
-  ${InfiniTime_DIR}/src/libs/QCBOR/src/qcbor_decode.c
-  ${InfiniTime_DIR}/src/libs/QCBOR/src/qcbor_encode.c
-  ${InfiniTime_DIR}/src/libs/QCBOR/src/qcbor_err_to_str.c
-  ${InfiniTime_DIR}/src/libs/QCBOR/src/UsefulBuf.c)
-target_include_directories(QCBOR SYSTEM PUBLIC ${InfiniTime_DIR}/src/libs/QCBOR/inc)
-# This is required with the current configuration
-target_compile_definitions(QCBOR PUBLIC QCBOR_DISABLE_FLOAT_HW_USE)
-# These are for space-saving
-target_compile_definitions(QCBOR PUBLIC QCBOR_DISABLE_PREFERRED_FLOAT)
-target_compile_definitions(QCBOR PUBLIC QCBOR_DISABLE_EXP_AND_MANTISSA)
-target_compile_definitions(QCBOR PUBLIC QCBOR_DISABLE_INDEFINITE_LENGTH_STRINGS)
-#target_compile_definitions(QCBOR PUBLIC QCBOR_DISABLE_INDEFINITE_LENGTH_ARRAYS)
-target_compile_definitions(QCBOR PUBLIC QCBOR_DISABLE_UNCOMMON_TAGS)
-target_compile_definitions(QCBOR PUBLIC USEFULBUF_CONFIG_LITTLE_ENDIAN)
-set_target_properties(QCBOR PROPERTIES LINKER_LANGUAGE C)
-#target_compile_options(QCBOR PRIVATE
-#        $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:DEBUG>>: ${COMMON_FLAGS} -O0 -g3>
-#        $<$<AND:$<COMPILE_LANGUAGE:C>,$<CONFIG:RELEASE>>: ${COMMON_FLAGS} -O3>
-#        $<$<COMPILE_LANGUAGE:ASM>: -MP -MD -x assembler-with-cpp>
-#        )
-target_link_libraries(infinisim PRIVATE QCBOR)
-
 # check version number of installed node package for minimum required
 find_program(NODE_EXE "node" NO_CACHE QUIET)
 if(NODE_EXE)


### PR DESCRIPTION
The current firmware 1.14.0 doesn't use QCBOR in its code. Remove this removed residual dependency.