### PR TITLE
Update github actions to new version

### DIFF
--- a/.github/workflows/lv_sim.yml
+++ b/.github/workflows/lv_sim.yml
@@ -46,7 +46,7 @@ jobs:
       # Checkout
 
       - name: Checkout source files
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -68,13 +68,13 @@ jobs:
           cmake --build build_lv_sim
 
       - name: Upload simulator executable
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: infinisim
           path: build_lv_sim/infinisim
 
       - name: Upload littlefs-do executable
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: littlefs-do
           path: build_lv_sim/littlefs-do


### PR DESCRIPTION
Same as InfiniTime, InfiniSim should be updated to use the new GitHub Actions.
https://github.com/InfiniTimeOrg/InfiniTime/pull/2224