### PR TITLE
Docker Image to build InfiniSim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:22.04
+
+# Install dependencies
+RUN apt-get update && \
+    apt-get install -y \
+    curl \
+    cmake \
+    libsdl2-dev \
+    g++ \
+    python3-pip \
+    python3-venv \
+    libpng-dev \
+    git \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh \
+    && bash nodesource_setup.sh \
+    && apt-get install -y nodejs \
+    && npm install -g lv_font_conv@1.5.2 \
+    && pip install wheel Pillow
+
+
+WORKDIR /sources
+
+# Define build configuration environment variables with default values
+ENV INFITIME_DIR="/sources/InfiniTime"
+ENV BUILD_FLAGS=""
+
+CMD ["bash", "-c", "cmake -S . -B build -DInfiniTime_DIR=${INFITIME_DIR} ${BUILD_FLAGS} && cmake --build build -j4"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,26 @@
 FROM ubuntu:22.04
 
 # Install dependencies
-RUN apt-get update && \
+ARG DEBIAN_FRONTEND=noninteractive
+ARG NODE_MAJOR=20
+RUN apt-get update -qq && \
     apt-get install -y \
     curl \
     cmake \
     libsdl2-dev \
     g++ \
+    libpng-dev \
     python3-pip \
     python3-venv \
-    libpng-dev \
-    git \
-    && rm -rf /var/lib/apt/lists/* \
-    && curl -sL https://deb.nodesource.com/setup_20.x -o nodesource_setup.sh \
+    && rm -rf /var/cache/apt/* /var/lib/apt/lists/* \
+    && curl -sL https://deb.nodesource.com/setup_${NODE_MAJOR}.x -o nodesource_setup.sh \
     && bash nodesource_setup.sh \
     && apt-get install -y nodejs \
     && npm install -g lv_font_conv@1.5.2 \
     && pip install wheel Pillow
 
-
 WORKDIR /sources
-
-# Define build configuration environment variables with default values
+# Build configuration environment variables
 ENV INFITIME_DIR="/sources/InfiniTime"
 ENV BUILD_FLAGS=""
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,30 @@ The following configuration settings can be added to the first `cmake -S . -B bu
   Ex: `-DENABLE_USERAPPS="Apps::Timer, Apps::Alarm"`.
   The default list of user applications will be selected if this variable is not set.
 
+### Build with Docker
+
+You can also build the simulator using Docker. This is useful if you don't want to install all the dependencies on your system.
+First build the Docker image:
+```sh
+docker build -t infinisim-build .
+```
+
+Afterwards you can build the simulator with:
+```sh
+docker run --rm -it -v ${PWD}:/sources infinisim-build
+```
+
+By default this builds the InfiniTime from the submodule in your ${PWD}. If you want to use a different repository, you got to mount it and pass the path to the `INFITIME_DIR` variable:
+```sh
+docker run --rm -it -v ${PWD}:/sources -v ${PWD}/../InfiniTime:/infinitime -e INFITIME_DIR=/infinitime infinisim-build
+```
+
+Other build configurations can be passed to the BUILD_FLAGS variable:
+```sh
+docker run --rm -it -v ${PWD}:/sources -e BUILD_FLAGS=-DENABLE_USERAPPS="Apps::MyApp,Apps::Alarm" infinisim-build
+```
+
+
 ## Run Simulator
 
 When the build was successful the simulator binary can be started with


### PR DESCRIPTION
This PR adds a Dockerfile that allows to build InfiniSim in a pre-configured, separate environment. It follows the structure and idea of the [InfiniTime Dockerfile](https://github.com/InfiniTimeOrg/InfiniTime/blob/main/docker/Dockerfile). Furthermore instructions are added to the README.md. 