### PR TITLE
fix: ignore development files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,9 @@ Testing/Temporary/
 src/nRF5_SDK_15.3.0_59ac345
 src/arm-none-eabi
 
+# Developer files
+CMakeUserPresets.json
+compile_commands.json
+package-lock.json
+package.json
+node_modules/


### PR DESCRIPTION
As request in https://github.com/InfiniTimeOrg/InfiniSim/pull/176#discussion_r2137575519 

This PR adds some autogenerated development files to the gitignore file