### PR TITLE
Make dev container compatible with podman

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -48,8 +48,6 @@ RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhisto
     && chown -R $USERNAME /commandhistory \
     && echo "$SNIPPET" >> "/home/$USERNAME/.bashrc"
 
-USER ubuntu
-
 # Section for interactive compilation during docker run
 
 WORKDIR /sources

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ Afterwards you can build the simulator with:
 docker run --rm -it -v ${PWD}:/sources --user $(id -u):$(id -g) infinisim-build
 ```
 
+Note: when using rootless `podman` instead of `docker` the `--user` part can be left out.
+The command to build the simulator using `podman` is:
+```sh
+podman run --rm -it -v ${PWD}:/sources infinisim-build
+```
+
 By default this builds the simulator using the InfiniTime files from the submodule in your `${PWD}`.
 If you want to use a different repository, you got to mount it and pass the path to the `INFINITIME_DIR` variable:
 ```sh

--- a/README.md
+++ b/README.md
@@ -121,18 +121,18 @@ docker build -t infinisim-build .devcontainer
 
 Afterwards you can build the simulator with:
 ```sh
-docker run --rm -it -v ${PWD}:/sources infinisim-build
+docker run --rm -it -v ${PWD}:/sources --user $(id -u):$(id -g) infinisim-build
 ```
 
 By default this builds the simulator using the InfiniTime files from the submodule in your `${PWD}`.
 If you want to use a different repository, you got to mount it and pass the path to the `INFINITIME_DIR` variable:
 ```sh
-docker run --rm -it -v ${PWD}:/sources -v ${PWD}/../InfiniTime:/infinitime -e INFINITIME_DIR=/infinitime infinisim-build
+docker run --rm -it -v ${PWD}:/sources -v ${PWD}/../InfiniTime:/infinitime -e INFINITIME_DIR=/infinitime  --user $(id -u):$(id -g) infinisim-build
 ```
 
 Other CMake generation and build arguments can be passed to the `GENERATE_ARGS` and `BUILD_ARGS` variables:
 ```sh
-docker run --rm -it -v ${PWD}:/sources -e GENERATE_ARGS=-DENABLE_USERAPPS="Apps::Timer,Apps::Alarm" -e BUILD_ARGS=-j16 infinisim-build
+docker run --rm -it -v ${PWD}:/sources -e GENERATE_ARGS=-DENABLE_USERAPPS="Apps::Timer,Apps::Alarm" -e BUILD_ARGS=-j16 --user $(id -u):$(id -g)  infinisim-build
 ```
 
 


### PR DESCRIPTION
Follow up to the issue described in https://github.com/InfiniTimeOrg/InfiniSim/pull/174#discussion_r2150883468. This prevents permission issues when using the dev container with podman, which is running rootless. Usage with docker then requires explicitly passing UID and GID of the local user. To produce artifacts owned by the local user. The command in the README is adjusted.