### PR TITLE
cmake: print status message with found SDL2 version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ target_include_directories(sim-base PUBLIC "lv_drivers")
 target_include_directories(sim-base PUBLIC "${InfiniTime_DIR}/src") # InfiniTime drivers, components and all
 
 find_package(SDL2 REQUIRED)
+message(STATUS "Found SDL2 version ${SDL2_VERSION}")
 target_link_libraries(sim-base PUBLIC SDL2::SDL2)
 
 set(MONITOR_ZOOM 1 CACHE STRING "Scale simulator window by this factor")


### PR DESCRIPTION
Sometimes it is nice to have the info which SDL2 version was found/is in use.