### PR TITLE
Fix LVGL thread race between the main thread and the DisplayApp task

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,8 @@ target_sources(infinisim PUBLIC
   sim/components/battery/BatteryController.cpp
   sim/components/ble/NimbleController.h
   sim/components/ble/NimbleController.cpp
+  sim/displayapp/LvglGuard.h
+  sim/displayapp/LvglGuard.cpp
   sim/components/brightness/BrightnessController.h
   sim/components/brightness/BrightnessController.cpp
   sim/components/firmwarevalidator/FirmwareValidator.h

--- a/main.cpp
+++ b/main.cpp
@@ -984,8 +984,10 @@ public:
   // render the current status of the simulated controller
   void refresh_screen() {
     // Serialize against the DisplayApp task: both this function and the
-    // display task drive LVGL (see sim/displayapp/LvglGuard.h).
-    LVGL_GUARD();
+    // display task drive LVGL. Non-blocking on purpose — the main loop also
+    // pumps SDL input, so it must never park on this lock
+    // (see sim/displayapp/LvglGuard.h). A skipped overlay frame is harmless.
+    LVGL_TRY_GUARD();
     const Pinetime::Controllers::BrightnessController::Levels level = brightnessController.Level();
     if (level == Pinetime::Controllers::BrightnessController::Levels::Off) {
       if (!screen_off_created) {

--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,7 @@
 
 // get PineTime header
 #include "displayapp/InfiniTimeTheme.h"
+#include "displayapp/LvglGuard.h"
 #include <drivers/Hrs3300.h>
 #include <drivers/Bma421.h>
 
@@ -982,6 +983,9 @@ public:
 
   // render the current status of the simulated controller
   void refresh_screen() {
+    // Serialize against the DisplayApp task: both this function and the
+    // display task drive LVGL (see sim/displayapp/LvglGuard.h).
+    LVGL_GUARD();
     const Pinetime::Controllers::BrightnessController::Levels level = brightnessController.Level();
     if (level == Pinetime::Controllers::BrightnessController::Levels::Off) {
       if (!screen_off_created) {

--- a/sim/displayapp/LvglGuard.cpp
+++ b/sim/displayapp/LvglGuard.cpp
@@ -1,0 +1,7 @@
+#include "displayapp/LvglGuard.h"
+
+namespace Pinetime {
+  namespace Sim {
+    std::recursive_mutex lvglMutex;
+  }
+}

--- a/sim/displayapp/LvglGuard.h
+++ b/sim/displayapp/LvglGuard.h
@@ -1,0 +1,20 @@
+#pragma once
+
+// Shadows InfiniTime's no-op displayapp/LvglGuard.h (the sim include path wins).
+//
+// LVGL is not thread-safe, and unlike the watch the simulator has TWO threads
+// driving it: the DisplayApp task, and the SDL main thread which renders the
+// "Screen is OFF" overlay (and runs lv_task_handler while the display task
+// sleeps). The wake/sleep handoff between them is a use-after-free factory —
+// AddressSanitizer showed main-thread lv_obj_del(screen_off_bg) racing the
+// display task's lv_task_handler. This mutex serializes both sides.
+
+#include <mutex>
+
+namespace Pinetime {
+  namespace Sim {
+    extern std::recursive_mutex lvglMutex;
+  }
+}
+
+#define LVGL_GUARD() std::lock_guard<std::recursive_mutex> lvglGuardLock(Pinetime::Sim::lvglMutex)

--- a/sim/displayapp/LvglGuard.h
+++ b/sim/displayapp/LvglGuard.h
@@ -8,6 +8,19 @@
 // sleeps). The wake/sleep handoff between them is a use-after-free factory —
 // AddressSanitizer showed main-thread lv_obj_del(screen_off_bg) racing the
 // display task's lv_task_handler. This mutex serializes both sides.
+//
+// The two sides lock differently on purpose:
+//
+//   LVGL_GUARD()      blocking. Used by the DisplayApp task, whose whole job is
+//                     LVGL: if the main thread is mid-overlay it must wait.
+//
+//   LVGL_TRY_GUARD()  non-blocking. Used by the SDL main thread, which also
+//                     pumps SDL events and the GATT bridge. It must never park
+//                     on a lock held by another thread: doing so would let any
+//                     stall inside the display task wedge the whole process
+//                     (input dead, bridge unresponsive) instead of merely
+//                     freezing the watch screen. Missing an overlay refresh is
+//                     harmless — the main loop runs again in ~30 ms.
 
 #include <mutex>
 
@@ -18,3 +31,10 @@ namespace Pinetime {
 }
 
 #define LVGL_GUARD() std::lock_guard<std::recursive_mutex> lvglGuardLock(Pinetime::Sim::lvglMutex)
+
+// Skips the enclosing function when the display task holds the lock.
+#define LVGL_TRY_GUARD()                                                                                                                   \
+  std::unique_lock<std::recursive_mutex> lvglGuardLock(Pinetime::Sim::lvglMutex, std::try_to_lock);                                        \
+  if (!lvglGuardLock.owns_lock()) {                                                                                                        \
+    return;                                                                                                                                \
+  }


### PR DESCRIPTION
The complete fix needs a small companion change in InfiniTime: InfiniTimeOrg/InfiniTime#2447. 

## The bug

LVGL is not thread-safe, but InfiniSim drives it from two threads:

- the DisplayApp task, LVGL's normal owner (`lv_task_handler`, screen loads), and
- the SDL main thread, whose `refresh_screen()` creates and deletes the "Screen is OFF" overlay objects and runs `lv_task_handler` while the display task sleeps.

The wake/sleep handoff between the two corrupts the LVGL heap. It reproduces easily. Toggle sleep/wake with the right mouse button every ~600 ms, and an AddressSanitizer build crashes within about 4 cycles:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 8 ... in get_property_index lvgl/src/lv_core/lv_style.c:996
    ... _lv_disp_refr_task <- lv_task_handler <- DisplayApp::Refresh   (thread "displayapp")
freed by thread T0 (main) here:
    ... lv_obj_del <- Framework::refresh_screen <- Framework::refresh <- main
previously allocated by thread T0 here:
    ... lv_obj_set_style_local_bg_color <- Framework::refresh_screen  (screen_off_bg)
```

In a normal build the same corruption surfaces later as a SIGSEGV in the style walk during refresh (`_lv_style_get_int` reading a freed style map). The existing `screen_off_delete_cb` double-free guard covers one symptom but not the underlying race.

## The fix

A `std::recursive_mutex` behind `LVGL_GUARD()` (`sim/displayapp/LvglGuard.h`), with the two sides locking differently on purpose:

- the DisplayApp task takes it blocking, since LVGL is its whole job;
- the main thread takes it with `try_lock` (`LVGL_TRY_GUARD()`) and skips the overlay frame if the display task holds it. The main loop also pumps SDL input, so it must never park on a lock held by another thread. Doing so would turn any stall inside the display task into a whole-process wedge, dead input, rather than a frozen watch screen. A skipped overlay frame is harmless; the loop runs again about 30 ms later. I hit exactly this while testing a blocking first version: the process stayed alive with the main thread in `futex_wait`.

The other half of the race is the DisplayApp task itself, which is InfiniTime code. InfiniTimeOrg/InfiniTime#2447 adds a no-op `displayapp/LvglGuard.h` to InfiniTime and takes `LVGL_GUARD()` around the two LVGL regions of `DisplayApp::Refresh`, not across the blocking queue wait. On hardware the macro compiles to nothing, since LVGL has a single owner there. In the sim, this repo's header shadows it via include-path order (the same mechanism the sim already uses for `nrf_log.h`), so both threads serialize.

Without the InfiniTime side, this change alone is safe but only partial: it serializes the overlay operations against the sim's own off-screen `lv_task_handler`, not against the display task.

## Verification

- Stress: 300 wake/sleep cycles under ASan, zero reports, sim alive. Unfixed, it crashes at cycle 4.
- This branch compiles standalone against the vendored InfiniTime submodule (`cmake && make`), no new warnings.
- Normal interactive use, and alarms and notifications firing from sleep, are unaffected.