### PR TITLE
semphr: implement the FreeRTOS recursive mutex API

### DIFF
--- a/sim/semphr.cpp
+++ b/sim/semphr.cpp
@@ -1,5 +1,6 @@
 #include "semphr.h"
 #include <SDL.h>
+#include <mutex>
 #include <stdexcept>
 
 QueueHandle_t xSemaphoreCreateMutex() {
@@ -38,5 +39,20 @@ BaseType_t xSemaphoreGive(SemaphoreHandle_t xSemaphore) {
     throw std::runtime_error("Mutex released without being held");
   }
   pxQueue->queue.pop_back();
+  return true;
+}
+
+SemaphoreHandle_t xSemaphoreCreateRecursiveMutex() {
+  // Only ever locked with portMAX_DELAY, so std::recursive_mutex maps directly.
+  return reinterpret_cast<SemaphoreHandle_t>(new std::recursive_mutex());
+}
+
+BaseType_t xSemaphoreTakeRecursive(SemaphoreHandle_t xSemaphore, TickType_t /*xTicksToWait*/) {
+  reinterpret_cast<std::recursive_mutex*>(xSemaphore)->lock();
+  return true;
+}
+
+BaseType_t xSemaphoreGiveRecursive(SemaphoreHandle_t xSemaphore) {
+  reinterpret_cast<std::recursive_mutex*>(xSemaphore)->unlock();
   return true;
 }

--- a/sim/semphr.h
+++ b/sim/semphr.h
@@ -9,3 +9,10 @@ QueueHandle_t xSemaphoreCreateMutex();
 
 BaseType_t xSemaphoreTake(SemaphoreHandle_t xSemaphore, TickType_t xTicksToWait);
 BaseType_t xSemaphoreGive(SemaphoreHandle_t xSemaphore);
+
+// Recursive mutex, as used by FS. Handles from xSemaphoreCreateRecursiveMutex
+// must only be passed to the *Recursive functions and vice versa (same rule as
+// real FreeRTOS).
+SemaphoreHandle_t xSemaphoreCreateRecursiveMutex();
+BaseType_t xSemaphoreTakeRecursive(SemaphoreHandle_t xSemaphore, TickType_t xTicksToWait);
+BaseType_t xSemaphoreGiveRecursive(SemaphoreHandle_t xSemaphore);


### PR DESCRIPTION
Companion to InfiniTimeOrg/InfiniTime#2449, which adds a recursive mutex inside `Controllers::FS` to make littlefs access thread-safe. The firmware's `FS.cpp` is compiled into both the simulator and `littlefs-do`, so the FreeRTOS shim needs `xSemaphoreCreateRecursiveMutex`, `xSemaphoreTakeRecursive` and `xSemaphoreGiveRecursive`.

Implementation: a `std::recursive_mutex` behind the semaphore handle. The timeout argument is ignored; the only firmware caller uses `portMAX_DELAY`, matching the blocking lock. Handles from `xSemaphoreCreateRecursiveMutex` must only be used with the `*Recursive` functions and vice versa, which is the same rule real FreeRTOS imposes.

This change is additive and safe to merge independently: it compiles against current InfiniTime main (the new functions are simply unused until the FS change lands). Verified locally in the same combination InfiniTime's `build-simulator` CI job uses: this branch built with `-DInfiniTime_DIR` pointing at InfiniTime main plus the FS mutex patch, both `infinisim` and `littlefs-do` link and run.

Merging this first unblocks the `build-simulator` check on the InfiniTime PR, since that job clones InfiniSim main.