### PR TITLE
Enforce the simulated heap budget in pvPortMalloc

### DIFF
--- a/sim/FreeRTOS.cpp
+++ b/sim/FreeRTOS.cpp
@@ -1,8 +1,11 @@
 #include "FreeRTOS.h"
-#include <numeric>
 #include <unordered_map>
 #include <stdio.h>
 #include <stdlib.h>
+
+// Defined by the simulator main, mirroring the counter the firmware keeps in
+// its vApplicationMallocFailedHook and shows in Sys Info.
+extern int mallocFailedCount;
 
 void NVIC_SystemReset(void) {
 }
@@ -16,6 +19,7 @@ namespace {
 
   struct HeapTracking {
     std::unordered_map<void*, size_t> allocatedMemory;
+    size_t used = 0;
     size_t currentFreeHeap = configTOTAL_HEAP_SIZE;
     size_t minimumEverFreeHeap = configTOTAL_HEAP_SIZE;
 
@@ -29,31 +33,75 @@ namespace {
   };
 
   HeapTracking heapTracking;
+
+  // Bytes withheld from the budget, from INFINISIM_HEAP_BALLAST. The simulator
+  // reports far more free heap than a watch does, for two reasons: it carries no
+  // BLE stack, and InfiniTime's stdlib.c, which routes malloc/new/littlefs onto
+  // this heap on the device, is not part of this build, so those allocations go
+  // to the host heap untracked. Rather than model that, withhold the difference
+  // you measure against Sys Info on a real watch. Read once.
+  size_t HeapBallast() {
+    static const size_t ballast = [] {
+      const char* env = getenv("INFINISIM_HEAP_BALLAST");
+      size_t value = env != nullptr ? strtoul(env, nullptr, 10) : 0;
+      if (value >= configTOTAL_HEAP_SIZE) {
+        fprintf(stderr, "[heap] INFINISIM_HEAP_BALLAST=%zu leaves nothing of %d, clamping\n", value, configTOTAL_HEAP_SIZE);
+        value = configTOTAL_HEAP_SIZE - 1;
+      }
+      if (value > 0) {
+        fprintf(stderr, "[heap] reserving %zu bytes, %zu of %d usable\n", value, configTOTAL_HEAP_SIZE - value, configTOTAL_HEAP_SIZE);
+      }
+      return value;
+    }();
+    return ballast;
+  }
+
+  void UpdateFree() {
+    heapTracking.currentFreeHeap = configTOTAL_HEAP_SIZE - heapTracking.used - HeapBallast();
+    heapTracking.minimumEverFreeHeap = std::min(heapTracking.currentFreeHeap, heapTracking.minimumEverFreeHeap);
+  }
 }
 
 void* pvPortMalloc(size_t xWantedSize) {
+  if (heapTrackingAlive && heapTracking.used + HeapBallast() + xWantedSize > configTOTAL_HEAP_SIZE) {
+    // What heap_4 does on the watch when it cannot satisfy a request. Returning
+    // host memory here instead would hide every allocation failure the firmware
+    // is written to cope with. Announce the first one, since whatever the caller
+    // does with the null pointer is easier to read with the cause in the log.
+    UpdateFree();
+    if (mallocFailedCount == 0) {
+      fprintf(stderr, "[heap] allocation of %zu bytes failed, %zu free; further failures counted only\n", xWantedSize, heapTracking.currentFreeHeap);
+    }
+    mallocFailedCount++;
+    return nullptr;
+  }
+
   void* ptr = malloc(xWantedSize);
-  if (!heapTrackingAlive) {
+  if (!heapTrackingAlive || ptr == nullptr) {
     return ptr;
   }
+  // Drop any stale size still recorded against this address before adding the
+  // new one. A running total only stays correct if every insertion is matched,
+  // and the accumulate this replaces was self-correcting by construction.
+  const auto previous = heapTracking.allocatedMemory.find(ptr);
+  if (previous != heapTracking.allocatedMemory.end()) {
+    heapTracking.used -= previous->second;
+  }
   heapTracking.allocatedMemory[ptr] = xWantedSize;
-
-  const size_t currentSize = std::accumulate(heapTracking.allocatedMemory.begin(),
-                                             heapTracking.allocatedMemory.end(),
-                                             0,
-                                             [](const size_t lhs, const std::pair<void*, size_t>& item) {
-                                               return lhs + item.second;
-                                             });
-
-  heapTracking.currentFreeHeap = configTOTAL_HEAP_SIZE - currentSize;
-  heapTracking.minimumEverFreeHeap = std::min(heapTracking.currentFreeHeap, heapTracking.minimumEverFreeHeap);
+  heapTracking.used += xWantedSize;
+  UpdateFree();
 
   return ptr;
 }
 
 void vPortFree(void* pv) {
   if (heapTrackingAlive) {
-    heapTracking.allocatedMemory.erase(pv);
+    const auto entry = heapTracking.allocatedMemory.find(pv);
+    if (entry != heapTracking.allocatedMemory.end()) {
+      heapTracking.used -= entry->second;
+      heapTracking.allocatedMemory.erase(entry);
+      UpdateFree();
+    }
   }
   free(pv);
 }


### PR DESCRIPTION
`pvPortMalloc` in `sim/FreeRTOS.cpp` forwards every request to the host `malloc`, so the simulated heap never runs out. `configTOTAL_HEAP_SIZE` is tracked for reporting, but nothing is ever checked against it.

The consequence is that a class of firmware behaviour cannot be exercised in the simulator at all:

- `mallocFailedCount` has no writer in the simulator, so Sys Info's allocation error count is permanently zero no matter what the firmware does. On the watch, `heap_4` drives it through `vApplicationMallocFailedHook`.
- Every code path that tests a `pvPortMalloc` result for null is unreachable.
- `lv_conf.h` sets `LV_MEM_CUSTOM_ALLOC` to `pvPortMalloc`, so LVGL allocates through it too. `lv_obj_create`, `lv_label_create` and `lv_font_load` can return null on the watch and never do in the simulator.

This is one of the few places where the simulator diverges from the watch in a direction that hides bugs rather than exposing them.

## Change

`pvPortMalloc` returns null and increments `mallocFailedCount` when a request would exceed the budget, which is what `heap_4` does on the watch. The first failure prints one line to stderr naming the size and the free count, so that if the caller dereferences the null the log says why. Later failures are counted only.

Enforcement alone does not accomplish much, because the simulator reports far more free heap than a watch does. Two separate reasons, and the second is easy to miss:

1. It carries no BLE stack, so it never allocates what NimBLE and its buffers hold.
2. `InfiniTime/src/stdlib.c`, which redirects `malloc`, `free`, `calloc` and `realloc` onto the FreeRTOS heap, is not part of the simulator build. On the watch that makes plain `malloc`, C++ `new` and littlefs's buffers count against the budget. In the simulator they go to the host heap untracked, so the simulator is measuring a strictly smaller set of allocations.

`INFINISIM_HEAP_BALLAST` withholds a fixed number of bytes from the budget, which closes that gap empirically rather than trying to model it. Pick the value by measurement: take the free heap the simulator reports, subtract what Sys Info reports on your watch at the same screen, and use the difference.

The `std::accumulate` over the allocation map is replaced with a running total. It was O(n) per allocation and previously ran once per allocation; the budget check now runs on every one. The accumulate was self-correcting by construction, so the running total explicitly drops any stale size recorded against an address before adding the new one, to keep that property.

Heap tracking is unsynchronised in the simulator today. This patch does not change that, and does not add a lock.

## No dependency on my own fork

I develop against a fork, and that is where this started, so to be explicit: the patch is one file, `sim/FreeRTOS.cpp`. There is no InfiniTime-side change of any kind, and both symbols it touches are already InfiniSim's own, `mallocFailedCount` at `main.cpp:1088` and `configTOTAL_HEAP_SIZE` at `sim/FreeRTOS.h:87`.

Everything below was produced with the vendored `InfiniTime` submodule at `8a9ccf21`, unmodified.

## Results on upstream InfiniTime

Boot, then idle for 20 s, three runs at each value. Free heap is the firmware's own `initial free_size` line.

| `INFINISIM_HEAP_BALLAST` | free heap | result |
|---|---|---|
| unset | 40360 | boots, idles |
| 25000 | 15360 | boots, idles |
| 30000 | 10360 | boots, idles |
| 32000 | 8360 | boots, idles |
| 34000 | 6360 | boots, then an allocation fails and it stops |
| 35000 | 5360 | allocation fails before it settles |

Free heap tracks the reservation exactly at every value, and the results were the same in all three runs. 25000 and 32000 were also run for 60 s with no failures, so the clean rows are not just short runs.

Two caveats on that table. The failing point is a property of the workload, not a constant: an idle simulator allocates less than one being driven through screens, so a heavier workload will fail higher. And the boundary is where it is because the firmware is genuinely out of memory, so the exact value is not meaningful beyond telling you which side of it you are on.

Nothing here says stock upstream firmware is at risk. It is not: a device sits far above this range, and these failures only appear once free heap is driven into single-digit kilobytes deliberately.

What the failures do expose is that the failure path itself is unhandled:

```
[heap] reserving 36000 bytes, 4960 of 40960 usable
[heap] allocation of 144 bytes failed, 72 free; further failures counted only

Thread 25 "displayapp" received signal SIGSEGV
#0  lv_area_get_width ()
#1  _lv_area_align ()
#2  obj_align_core ()
#3  lv_obj_align ()
#4  Pinetime::Applications::Screens::WatchFaceDigital::WatchFaceDigital(...)
#5  Pinetime::Applications::WatchFaceTraits<(WatchFace)0>::Create(AppControllers&)
#6  Pinetime::Applications::DisplayApp::LoadScreen(...)
```

An LVGL object allocation returns null, the constructor does not check it, and the next `lv_obj_align` reads through it. Treating LVGL allocation failure as impossible is a defensible stance for firmware that normally has headroom, and I am not proposing to change it here.

One detail cuts in the simulator's favour. On the nRF52, address 0 is flash and readable, so reading through a null pointer does not fault on the device. It returns whatever the vector table holds, which as geometry fields means plausible looking garbage rather than a stop. The same code in the simulator hits an unmapped page and stops immediately, with the allocation that caused it already named in the log. Where the watch degrades quietly, the simulator fails loudly.

## Why this is worth carrying

Firmware under development does reach this regime on real hardware. My own watch, running a face that loads four LVGL fonts from external flash, reports 7 allocation errors and a minimum-ever free heap of 1600 bytes in Sys Info, alongside display corruption I could not reproduce on a desktop for exactly the reason at the top of this description. With the budget enforced and the ballast set to the measured difference, the simulator sits at the same free heap as the device.

That part is fork-specific and none of it is needed to review the patch. It is why I went looking.

## Side effects

One behavioural change, and it is the point: the simulator refuses allocations past `configTOTAL_HEAP_SIZE` where it previously served them from the host heap. Firmware that was quietly exceeding the budget in simulation now sees a null, which is the null it would see on the watch.

With `INFINISIM_HEAP_BALLAST` unset, behaviour is unchanged and nothing is printed. I verified this rather than assuming it, by building the pristine `sim/FreeRTOS.cpp` and the patched one into otherwise identical binaries and diffing their output over repeated 20 s runs: identical, with the same 40360 free heap. Nothing in the default path can fail the new check, because the simulator does not approach 40 KB.

Free heap reporting is now updated on free as well as on alloc. Previously it was recomputed only on allocation, so the value could be stale after a burst of frees. This did not change the reported numbers in any run above.

Values at or above `configTOTAL_HEAP_SIZE` are clamped with a notice rather than underflowing the free count.

## Maintenance

One file, no new dependencies, no build flags, no CMake options, nothing added to the CLI or CI. The env var is read once into a function-local static. If nobody sets it, the cost is one `getenv` at first allocation and one comparison per allocation, against an `std::accumulate` removed from the same function.

## Testing

Built and run against the vendored `InfiniTime` submodule at `8a9ccf21`.

- Pristine versus patched binaries, ballast unset: byte-identical output across repeated runs, same free heap.
- The table above, three runs per value, plus 60 s runs at two of them.
- `INFINISIM_HEAP_BALLAST=99999`: clamped with a notice, no underflow.
- Starved: the failing allocation is named on stderr before the caller does anything with the null.

Marked draft. If you would rather not carry the env var, the enforcement can land alone, though without it the check rarely fires, for the reasons under Change. This does not depend on my other open PRs and touches no file they touch (#198 `LvglGuard`/`main.cpp`, #199 `sim/semphr.*`, #200 `LittleVgl`/`SpiNorFlash`/`host`).
